### PR TITLE
Add an option to develop in a reproducible and containerized environment

### DIFF
--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -1,0 +1,31 @@
+# Builder
+FROM node:10-alpine as builder
+
+# Support custom branches of the react-sdk and js-sdk. This also helps us build
+# images of riot-web develop.
+ARG USE_CUSTOM_SDKS=false
+ARG REACT_SDK_REPO="https://github.com/matrix-org/matrix-react-sdk.git"
+ARG REACT_SDK_BRANCH="master"
+ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
+ARG JS_SDK_BRANCH="master"
+
+RUN apk add --no-cache git dos2unix
+
+WORKDIR /src
+
+COPY . /src
+RUN dos2unix /src/scripts/docker-link-repos.sh && sh /src/scripts/docker-link-repos.sh
+RUN yarn --network-timeout=100000 install
+RUN yarn build
+
+# Copy the config now so that we don't create another layer in the app image
+RUN cp /src/config.sample.json /src/webapp/config.json
+
+
+# App
+FROM nginx:alpine
+
+COPY --from=builder /src/webapp /app
+
+RUN rm -rf /usr/share/nginx/html \
+ && ln -s /app /usr/share/nginx/html

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -27,3 +27,19 @@ COPY package.json yarn.lock /src/
 RUN sed -i -e '/"prepare":/d' /src/package.json
 RUN yarn --network-timeout=100000 install
 
+# Overlay src files with the original ones in case something was left out
+# from explicit copying above and doesn't work with mounting properly such as:
+#
+# "ERROR in Entry module not found: Error: Can't resolve './src' in '/src'"
+# "ERROR in multi (webpack)-dev-server/client?http://0.0.0.0 ./src"
+COPY . /src
+
+# Assemble entrypoint that copies the config at container start
+# and runs webpack server. Mount volume to /src/src for developing.
+RUN echo 'mkdir /src/webapp' >> /entry.sh \
+    && echo 'cp /src/config.sample.json /src/webapp/config.json' >> /entry.sh \
+    && echo 'yarn start' >> /entry.sh \
+    && chmod +x /entry.sh
+
+# run webpack server to change the code on-the-go
+ENTRYPOINT /entry.sh

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -38,6 +38,7 @@ COPY . /riot
 # and runs webpack server. Mount volume to /src/src for developing.
 RUN echo 'mkdir /riot/webapp' >> /entry.sh \
     && echo 'cp /riot/config.sample.json /riot/webapp/config.json' >> /entry.sh \
+    && echo 'sh /riot/scripts/docker-link-repos.sh' >> /entry.sh \
     && echo 'yarn start' >> /entry.sh \
     && chmod +x /entry.sh
 

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -11,33 +11,33 @@ ARG JS_SDK_BRANCH="master"
 # CRLF -> LF conversion
 RUN apk add --no-cache git dos2unix
 
-WORKDIR /src
+WORKDIR /riot
 
 # Install deps-only into separate Docker layer and run Riot when the container
 # starts, mount source as a volume and keep dev environment consistent
-COPY scripts /src/scripts
-RUN dos2unix /src/scripts/docker-link-repos.sh \
-    && sh /src/scripts/docker-link-repos.sh
+COPY scripts /riot/scripts
+RUN dos2unix /riot/scripts/docker-link-repos.sh \
+    && sh /riot/scripts/docker-link-repos.sh
 
 # Cache package.json
-COPY package.json yarn.lock /src/
+COPY package.json yarn.lock /riot/
 
 # Remove 'prepare' script because there is NO config in yarn and npm for
 # disabling it and is not necessary for development build
-RUN sed -i -e '/"prepare":/d' /src/package.json
+RUN sed -i -e '/"prepare":/d' /riot/package.json
 RUN yarn --network-timeout=100000 install
 
 # Overlay src files with the original ones in case something was left out
 # from explicit copying above and doesn't work with mounting properly such as:
 #
-# "ERROR in Entry module not found: Error: Can't resolve './src' in '/src'"
+# "ERROR in Entry module not found: Error: Can't resolve './src' in '/riot'"
 # "ERROR in multi (webpack)-dev-server/client?http://0.0.0.0 ./src"
-COPY . /src
+COPY . /riot
 
 # Assemble entrypoint that copies the config at container start
 # and runs webpack server. Mount volume to /src/src for developing.
-RUN echo 'mkdir /src/webapp' >> /entry.sh \
-    && echo 'cp /src/config.sample.json /src/webapp/config.json' >> /entry.sh \
+RUN echo 'mkdir /riot/webapp' >> /entry.sh \
+    && echo 'cp /riot/config.sample.json /riot/webapp/config.json' >> /entry.sh \
     && echo 'yarn start' >> /entry.sh \
     && chmod +x /entry.sh
 

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -25,10 +25,4 @@ RUN yarn build
 RUN cp /src/config.sample.json /src/webapp/config.json
 
 
-# App
-FROM nginx:alpine
 
-COPY --from=builder /src/webapp /app
-
-RUN rm -rf /usr/share/nginx/html \
- && ln -s /app /usr/share/nginx/html

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -1,5 +1,4 @@
-# Builder
-FROM node:10-alpine as builder
+FROM node:10-alpine
 
 # Support custom branches of the react-sdk and js-sdk. This also helps us build
 # images of riot-web develop.
@@ -9,6 +8,7 @@ ARG REACT_SDK_BRANCH="master"
 ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
 ARG JS_SDK_BRANCH="master"
 
+# CRLF -> LF conversion
 RUN apk add --no-cache git dos2unix
 
 WORKDIR /src

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -13,8 +13,11 @@ RUN apk add --no-cache git dos2unix
 
 WORKDIR /src
 
-COPY . /src
-RUN dos2unix /src/scripts/docker-link-repos.sh && sh /src/scripts/docker-link-repos.sh
+# Install deps-only into separate Docker layer and run Riot when the container
+# starts, mount source as a volume and keep dev environment consistent
+COPY scripts /src/scripts
+RUN dos2unix /src/scripts/docker-link-repos.sh \
+    && sh /src/scripts/docker-link-repos.sh
 RUN yarn --network-timeout=100000 install
 RUN yarn build
 

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -20,11 +20,11 @@ RUN dos2unix /riot/scripts/docker-link-repos.sh \
     && sh /riot/scripts/docker-link-repos.sh
 
 # Cache package.json
+COPY src/header /riot/src/
 COPY package.json yarn.lock /riot/
 
 # Remove 'prepare' script because there is NO config in yarn and npm for
 # disabling it and is not necessary for development build
-RUN sed -i -e '/"prepare":/d' /riot/package.json
 RUN yarn --network-timeout=100000 install
 
 # Overlay src files with the original ones in case something was left out

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -18,11 +18,12 @@ WORKDIR /src
 COPY scripts /src/scripts
 RUN dos2unix /src/scripts/docker-link-repos.sh \
     && sh /src/scripts/docker-link-repos.sh
+
+# Cache package.json
+COPY package.json yarn.lock /src/
+
+# Remove 'prepare' script because there is NO config in yarn and npm for
+# disabling it and is not necessary for development build
+RUN sed -i -e '/"prepare":/d' /src/package.json
 RUN yarn --network-timeout=100000 install
-RUN yarn build
-
-# Copy the config now so that we don't create another layer in the app image
-RUN cp /src/config.sample.json /src/webapp/config.json
-
-
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ docker rm -f riot || true
 # run a new container with src folder mounted from git repository
 # located on the host machine. You can mount additional folders
 # such as res with additional --volume $PWD/res:/src/res
-docker run --detach --interactive --tty \
+docker run --interactive --tty \
     --publish <port-on-host>:8080 \
     --volume $PWD/src:/riot/src \
     --name riot \

--- a/README.md
+++ b/README.md
@@ -349,6 +349,27 @@ docker exec -it riot sh
 docker exec -it riot yarn
 ```
 
+In case you want to use own clones of
+[matrix-react-sdk](https://github.com/matrix-org/matrix-react-sdk)
+or
+[matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk)
+set additional environment variable ``USE_CUSTOM_SDKS`` in ``docker build``
+if it's a one-time operation. In case you want to use own clone and edit
+it at the same time as you edit ``riot-web``, set the environement
+variable in ``docker run`` command.
+
+```bash
+docker run --interactive --tty \
+    --publish <port-on-host>:8080 \
+    --volume $PWD/src:/riot/src \
+    --volume <path-to-matrix-js-sdk>:/riot/js-sdk \
+    --volume <path-to-matrix-react-sdk>:/riot/react-sdk \
+    --env USE_CUSTOM_SDKS=true \
+    --env NO_CLONE=true \
+    --name riot \
+    vectorim/riot-web:develop
+```
+
 Running the tests
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ and at the same time allows to plug in the folder with source files so that
 you can edit outside of Docker container and let it compile inside where
 it is safely separated from your machine or any custom configuration.
 
+Note that hot-reloading via an open websocket might not work out of the box
+on Windows, check [WebPack ``watchOptions.poll``](https://webpack.js.org/configuration/watch/)
+as a workaround.
+
 Using this approach provides a reproducible environment between you and
 the maintainers if you share your changes in a pull request.
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ docker rm -f riot || true
 # such as res with additional --volume $PWD/res:/src/res
 docker run --detach --interactive --tty \
     --publish <port-on-host>:8080 \
-    --volume $PWD/src:/src/src \
+    --volume $PWD/src:/riot/src \
     --name riot \
     vectorim/riot-web:develop
 ```

--- a/README.md
+++ b/README.md
@@ -304,6 +304,43 @@ If any of these steps error with, `file table overflow`, you are probably on a m
 which has a very low limit on max open files. Run `ulimit -Sn 1024` and try again.
 You'll need to do this in each new terminal you open before building Riot.
 
+Using Docker image for development
+----------------------------------
+
+Avoids installation of Node, NPM and the rest of the environment by providing
+the same environment that's used in serving Riot via Dockerfile officially
+and at the same time allows to plug in the folder with source files so that
+you can edit outside of Docker container and let it compile inside where
+it is safely separated from your machine or any custom configuration.
+
+Using this approach provides a reproducible environment between you and
+the maintainers if you share your changes in a pull request.
+
+Run it with:
+
+    # build image
+    docker build --tag vectorim/riot-web:develop --file Dockerfile.develop .
+
+    # remove old container or do nothing
+    docker rm -f riot || true
+
+    # run a new container with src folder mounted from git repository
+    # located on the host machine. You can mount additional folders
+    # such as res with additional --volume $PWD/res:/src/res
+    docker run --detach --interactive --tty \
+        --publish <port-on-host>:8080 \
+        --volume $PWD/src:/src/src \
+        --name riot \
+        vectorim/riot-web:develop
+
+And access ``yarn`` and other commands from inside of the container:
+
+    # run shell process from container
+    docker exec -it riot sh
+
+    # run yarn process from container
+    docker exec -it riot yarn
+
 Running the tests
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -318,28 +318,32 @@ the maintainers if you share your changes in a pull request.
 
 Run it with:
 
-    # build image
-    docker build --tag vectorim/riot-web:develop --file Dockerfile.develop .
+```bash
+# build image
+docker build --tag vectorim/riot-web:develop --file Dockerfile.develop .
 
-    # remove old container or do nothing
-    docker rm -f riot || true
+# remove old container or do nothing
+docker rm -f riot || true
 
-    # run a new container with src folder mounted from git repository
-    # located on the host machine. You can mount additional folders
-    # such as res with additional --volume $PWD/res:/src/res
-    docker run --detach --interactive --tty \
-        --publish <port-on-host>:8080 \
-        --volume $PWD/src:/src/src \
-        --name riot \
-        vectorim/riot-web:develop
+# run a new container with src folder mounted from git repository
+# located on the host machine. You can mount additional folders
+# such as res with additional --volume $PWD/res:/src/res
+docker run --detach --interactive --tty \
+    --publish <port-on-host>:8080 \
+    --volume $PWD/src:/src/src \
+    --name riot \
+    vectorim/riot-web:develop
+```
 
 And access ``yarn`` and other commands from inside of the container:
 
-    # run shell process from container
-    docker exec -it riot sh
+```bash
+# run shell process from container
+docker exec -it riot sh
 
-    # run yarn process from container
-    docker exec -it riot yarn
+# run yarn process from container
+docker exec -it riot yarn
+```
 
 Running the tests
 -----------------

--- a/scripts/docker-link-repos.sh
+++ b/scripts/docker-link-repos.sh
@@ -9,17 +9,27 @@ then
 fi
 
 echo "Linking js-sdk"
-git clone $JS_SDK_REPO js-sdk
+if [ -z ${NO_CLONE+x} ]
+then
+    git clone $JS_SDK_REPO js-sdk
+    cd js-sdk
+    git checkout $JS_SDK_BRANCH
+    cd ..
+fi
 cd js-sdk
-git checkout $JS_SDK_BRANCH
 yarn link
 yarn --network-timeout=100000 install
 cd ../
 
 echo "Linking react-sdk"
-git clone $REACT_SDK_REPO react-sdk
+if [ -z ${NO_CLONE+x} ]
+then
+    git clone $REACT_SDK_REPO react-sdk
+    cd react-sdk
+    git checkout $REACT_SDK_BRANCH
+    cd ..
+fi
 cd react-sdk
-git checkout $REACT_SDK_BRANCH
 yarn link
 yarn link matrix-js-sdk
 yarn --network-timeout=100000 install


### PR DESCRIPTION
Adds an option to develop this application in a containerized environment that provides reproducibility between multiple machines with the same change (branch / pull request / ...). In the less common approach it provides a way to develop applications (mainly web) without installing Node.js and maintain multiple dependencies, node_modules, etc on the host machine without an easy way to just burn everything down and start from scratch in case of a wrong approach.

Docker allows kind of `git stash` and `git stash pop` behavior with images therefore everything can be properly isolated, the changes can be done via mounting appropriate folders from host machine and in the worst case you can create an image via `docker commit` in case something went horribly wrong and you want your colleague to check it out on his/her machine (see [`docker save`](https://docs.docker.com/engine/reference/commandline/save/)). Currently the image takes about 855MB on my machine, but that might be later improved.

This way you can have an image for `develop`, `master`, `fix-12345`, etc and also work just fine on Riot X for example if it uses the same repo (not sure, haven't checked out yet). Storage nowadays isn't much of an issue I'd say, however having collisions between deps while working on multiple projects or the need to provide versions of multiple random binaries between colleagues just to reproduce why something does not work is rather inefficient.

Hopefully this will help somebody else other than me :)

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->