### PR TITLE
Terminate Jitsi widget gracefully before client drops its iframe

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -119,7 +119,7 @@ function joinConference() { // event handler bound in HTML
     if (avatarUrl) meetApi.executeCommand("avatarUrl", avatarUrl);
     if (userId) meetApi.executeCommand("email", userId);
 
-    let meetingClosed = new Promise(resolve => {
+    const meetingClosed = new Promise(resolve => {
         meetApi.on("readyToClose", () => {
             switchVisibleContainers();
 

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -35,7 +35,6 @@ let avatarUrl: string;
 let userId: string;
 
 let widgetApi: WidgetApi;
-let terminateMeeting: any;
 
 (async function () {
     try {
@@ -76,12 +75,6 @@ let terminateMeeting: any;
             await widgetApi.waitReady();
             await widgetApi.setAlwaysOnScreen(false); // start off as detachable from the screen
         }
-
-        widgetApi.addTerminateCallback(() => {
-            if (terminateMeeting) {
-                return terminateMeeting();
-            }
-        });
 
         // TODO: register widgetApi listeners for PTT controls (https://github.com/vector-im/riot-web/issues/12795)
 
@@ -140,11 +133,11 @@ function joinConference() { // event handler bound in HTML
         });
     });
 
-    terminateMeeting = () => {
+    widgetApi.once('terminate', (wait) => {
         // Hangup before the client terminates the widget. Don't show
         // the feedback dialog.
+        console.log("[Jitsi Widget] Client asks to terminate, hanging up");
         meetApi.executeCommand("hangup", false);
-        terminateMeeting = undefined;
-        return meetingClosed;
-    }
+        wait(meetingClosed);
+    });
 }


### PR DESCRIPTION
Add a cleanup hook for the Jitsi widget, which hangs the call up before the widget gets destroyed. This prevents abrupt disconnects that can leave "ghost" users lingering behind for several tens of seconds in the conference.

See https://github.com/matrix-org/matrix-react-sdk/pull/4444 (which contains the prerequisite widget API addition)

Part of https://github.com/vector-im/riot-web/issues/12986
Used by https://github.com/matrix-org/matrix-react-sdk/pull/4444