### PR TITLE
Update links in README.md to point to Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ released version of Element:
 
 1. Download the latest version from https://github.com/vector-im/element-web/releases
 1. Untar the tarball on your web server
-1. Move (or symlink) the `element-x.x.x` directory to an appropriate name
+1. Move (or symlink) the `riot-x.x.x` directory to an appropriate name
 1. Configure the correct caching headers in your webserver (see below)
 1. If desired, copy `config.sample.json` to `config.json` and edit it
    as desired. See the [configuration docs](docs/config.md) for details.
@@ -129,7 +129,7 @@ Running from Docker
 The Docker image can be used to serve element-web as a web server. The easiest way to use
 it is to use the prebuilt image:
 ```bash
-docker run -p 80:80 vectorim/element-web
+docker run -p 80:80 vectorim/riot-web
 ```
 
 To supply your own custom `config.json`, map a volume to `/app/config.json`. For example,
@@ -192,7 +192,7 @@ also defines the design, architecture and style for Element too.
 
 Before starting work on a feature, it's best to ensure your plan aligns well
 with our vision for Element. Please chat with the team in
-[#riot-dev:matrix.org](https://matrix.to/#/#riot-dev:matrix.org) before you
+[#element-dev:matrix.org](https://matrix.to/#/#element-dev:matrix.org) before you
 start so we can ensure it's something we'd be willing to merge.
 
 You should also familiarise yourself with the ["Here be Dragons" guide

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To supply your own custom `config.json`, map a volume to `/app/config.json`. For
 if your custom config was located at `/etc/element-web/config.json` then your Docker command
 would be:
 ```bash
-docker run -p 80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
+docker run -p 80:80 -v /etc/element-web/config.json:/app/config.json vectorim/riot-web
 ```
 
 To build the image yourself:
@@ -144,13 +144,13 @@ To build the image yourself:
 git clone https://github.com/vector-im/element-web.git element-web
 cd element-web
 git checkout master
-docker build -t vectorim/element-web .
+docker build .
 ```
 
 If you're building a custom branch, or want to use the develop branch, check out the appropriate
 element-web branch and then run:
 ```bash
-docker build -t vectorim/element-web:develop \
+docker build -t \
     --build-arg USE_CUSTOM_SDKS=true \
     --build-arg REACT_SDK_REPO="https://github.com/matrix-org/matrix-react-sdk.git" \
     --build-arg REACT_SDK_BRANCH="develop" \

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Element has several tiers of support for different environments:
   * Everything else
 
 For accessing Element on an Android or iOS device, we currently recommend the
-native apps [riot-android](https://github.com/vector-im/riot-android)
-and [riot-ios](https://github.com/vector-im/riot-ios).
+native apps [element-android](https://github.com/vector-im/element-android)
+and [element-ios](https://github.com/vector-im/element-ios).
 
 Getting Started
 ===============
@@ -37,9 +37,9 @@ for those who like living dangerously.
 To host your own copy of Element, the quickest bet is to use a pre-built
 released version of Element:
 
-1. Download the latest version from https://github.com/vector-im/riot-web/releases
+1. Download the latest version from https://github.com/vector-im/element-web/releases
 1. Untar the tarball on your web server
-1. Move (or symlink) the `riot-x.x.x` directory to an appropriate name
+1. Move (or symlink) the `element-x.x.x` directory to an appropriate name
 1. Configure the correct caching headers in your webserver (see below)
 1. If desired, copy `config.sample.json` to `config.json` and edit it
    as desired. See the [configuration docs](docs/config.md) for details.
@@ -69,7 +69,7 @@ access to Element (or other apps) due to sharing the same domain.
 
 We have put some coarse mitigations into place to try to protect against this
 situation, but it's still not good practice to do it in the first place.  See
-https://github.com/vector-im/riot-web/issues/1977 for more details.
+https://github.com/vector-im/element-web/issues/1977 for more details.
 
 Building From Source
 ====================
@@ -82,8 +82,8 @@ guide](https://classic.yarnpkg.com/en/docs/install) if you do not have it alread
 
 1. Install or update `node.js` so that your `node` is at least v10.x.
 1. Install `yarn` if not present already.
-1. Clone the repo: `git clone https://github.com/vector-im/riot-web.git`.
-1. Switch to the riot-web directory: `cd riot-web`.
+1. Clone the repo: `git clone https://github.com/vector-im/element-web.git`.
+1. Switch to the element-web directory: `cd element-web`.
 1. Install the prerequisites: `yarn install`.
    *  If you're using the `develop` branch, then it is recommended to set up a
       proper development environment (see [Setting up a dev
@@ -105,10 +105,10 @@ Running as a Desktop app
 ========================
 
 Element can also be run as a desktop app, wrapped in Electron. You can download a
-pre-built version from https://riot.im/download/desktop/ or, if you prefer,
+pre-built version from https://element.io/get-started or, if you prefer,
 build it yourself.
 
-To build it yourself, follow the instructions at https://github.com/vector-im/riot-desktop.
+To build it yourself, follow the instructions at https://github.com/vector-im/element-desktop.
 
 Many thanks to @aviraldg for the initial work on the Electron integration.
 
@@ -126,31 +126,31 @@ override the desktop app's default settings if desired.
 Running from Docker
 ===================
 
-The Docker image can be used to serve riot-web as a web server. The easiest way to use
+The Docker image can be used to serve element-web as a web server. The easiest way to use
 it is to use the prebuilt image:
 ```bash
-docker run -p 80:80 vectorim/riot-web
+docker run -p 80:80 vectorim/element-web
 ```
 
 To supply your own custom `config.json`, map a volume to `/app/config.json`. For example,
-if your custom config was located at `/etc/riot-web/config.json` then your Docker command
+if your custom config was located at `/etc/element-web/config.json` then your Docker command
 would be:
 ```bash
-docker run -p 80:80 -v /etc/riot-web/config.json:/app/config.json vectorim/riot-web
+docker run -p 80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
 ```
 
 To build the image yourself:
 ```bash
-git clone https://github.com/vector-im/riot-web.git riot-web
-cd riot-web
+git clone https://github.com/vector-im/element-web.git element-web
+cd element-web
 git checkout master
-docker build -t vectorim/riot-web .
+docker build -t vectorim/element-web .
 ```
 
 If you're building a custom branch, or want to use the develop branch, check out the appropriate
-riot-web branch and then run:
+element-web branch and then run:
 ```bash
-docker build -t vectorim/riot-web:develop \
+docker build -t vectorim/element-web:develop \
     --build-arg USE_CUSTOM_SDKS=true \
     --build-arg REACT_SDK_REPO="https://github.com/matrix-org/matrix-react-sdk.git" \
     --build-arg REACT_SDK_BRANCH="develop" \
@@ -169,7 +169,7 @@ Labs Features
 =============
 
 Some features of Element may be enabled by flags in the `Labs` section of the settings.
-Some of these features are described in [labs.md](https://github.com/vector-im/riot-web/blob/develop/docs/labs.md).
+Some of these features are described in [labs.md](https://github.com/vector-im/element-web/blob/develop/docs/labs.md).
 
 Caching requirements
 ====================
@@ -186,12 +186,12 @@ Element requires the following URLs not to be cached, when/if you are serving El
 Development
 ===========
 
-Before attempting to develop on Riot you **must** read the [developer guide
+Before attempting to develop on Element you **must** read the [developer guide
 for `matrix-react-sdk`](https://github.com/matrix-org/matrix-react-sdk#developer-guide), which
 also defines the design, architecture and style for Element too.
 
 Before starting work on a feature, it's best to ensure your plan aligns well
-with our vision for Riot. Please chat with the team in
+with our vision for Element. Please chat with the team in
 [#riot-dev:matrix.org](https://matrix.to/#/#riot-dev:matrix.org) before you
 start so we can ensure it's something we'd be willing to merge.
 
@@ -246,8 +246,8 @@ popd
 Finally, build and start Element itself:
 
 ```bash
-git clone https://github.com/vector-im/riot-web.git
-cd riot-web
+git clone https://github.com/vector-im/element-web.git
+cd element-web
 git checkout develop
 yarn link matrix-js-sdk
 yarn link matrix-react-sdk
@@ -275,7 +275,7 @@ bundle.css.map   116 kB       0  [emitted]  main
 Configure the app by copying `config.sample.json` to `config.json` and
 modifying it. See the [configuration docs](docs/config.md) for details.
 
-Open http://127.0.0.1:8080/ in your browser to see your newly built Riot.
+Open http://127.0.0.1:8080/ in your browser to see your newly built Element.
 
 **Note**: The build script uses inotify by default on Linux to monitor directories
 for changes. If the inotify watch limit is too low your build will silently fail.
@@ -336,7 +336,7 @@ To add a new translation, head to the [translating doc](docs/translating.md).
 
 For a developer guide, see the [translating dev doc](docs/translating-dev.md).
 
-[<img src="https://translate.riot.im/widgets/riot-web/-/multi-auto.svg" alt="translationsstatus" width="340">](https://translate.riot.im/engage/riot-web/?utm_source=widget)
+[<img src="https://translate.riot.im/widgets/element-web/-/multi-auto.svg" alt="translationsstatus" width="340">](https://translate.riot.im/engage/element-web/?utm_source=widget)
 
 Triaging issues
 ===============


### PR DESCRIPTION
There still one or two links pointing to Riot specific stuff, as there exists no equivalent for Element, at least as far as i know.

These are:
- [https://packages.riot.im/riot-release-key.asc](https://github.com/Weasy666/element-web/blame/develop/README.md#L49)
- [https://matrix.to/#/#riot-dev:matrix.org](https://github.com/Weasy666/element-web/blame/develop/README.md#L195)
- [https://translate.riot.im/engage/element-web/?utm_source=widget](https://github.com/Weasy666/element-web/blame/develop/README.md#L339)