### PR TITLE
Link to Element in F-Droid as well

### DIFF
--- a/src/async-components/structures/CompatibilityView.tsx
+++ b/src/async-components/structures/CompatibilityView.tsx
@@ -87,7 +87,7 @@ const CompatibilityView: React.FC<IProps> = ({ onAccept }) => {
                            className="mx_ClearDecoration">
                             <img height="48" src="themes/element/img/download/google.svg" alt="Google Play Store" />
                         </a>
-                        <a href="https://f-droid.org/repository/browse/?fdid=im.vector.alpha" target="_blank"
+                        <a href="https://f-droid.org/repository/browse/?fdid=im.vector.app" target="_blank"
                            className="mx_ClearDecoration">
                             <img height="48" src="themes/element/img/download/fdroid.svg" alt="F-Droid" />
                         </a>

--- a/src/vector/mobile_guide/index.html
+++ b/src/vector/mobile_guide/index.html
@@ -260,7 +260,7 @@ body {
                         </g>
                     </g>
                 </svg>
-              <a href="https://f-droid.org/repository/browse/?fdid=im.vector.alpha" target="_blank" class="mx_ClearDecoration">
+              <a href="https://f-droid.org/repository/browse/?fdid=im.vector.app" target="_blank" class="mx_ClearDecoration">
                 <svg width="164px" height="48px" viewBox="0 0 157 46" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                     <desc>Get it on F-Droid.</desc>
                     <defs>

--- a/src/vector/static/incompatible-browser.html
+++ b/src/vector/static/incompatible-browser.html
@@ -339,7 +339,7 @@
                         </g>
                     </svg>
                 </a>
-                <a href="https://f-droid.org/repository/browse/?fdid=im.vector.alpha" target="_blank"
+                <a href="https://f-droid.org/repository/browse/?fdid=im.vector.app" target="_blank"
                    class="mx_ClearDecoration">
                     <svg width="164px" height="48px" viewBox="0 0 157 46" version="1.1"
                          xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
The old app-id shows a big warning that it will no longer be maintained,
so avoid linking to it (especially for self-hosted element-web installs).

Signed-off-by: Christoph Settgast <csett86@web.de>