### PR TITLE
Document .well-known E2EE secure backup setting

### DIFF
--- a/docs/e2ee.md
+++ b/docs/e2ee.md
@@ -10,7 +10,7 @@ Set the following on your homeserver's
 
 ```json
 {
-  "im.vector.e2ee": {
+  "io.element.e2ee": {
     "default": false
   }
 }
@@ -29,8 +29,8 @@ following on your homeserver's `/.well-known/matrix/client` config:
 
 ```json
 {
-  "im.vector.e2ee": {
-    "secureBackupRequired": true
+  "io.element.e2ee": {
+    "secure_backup_required": true
   }
 }
 ```
@@ -39,4 +39,4 @@ following on your homeserver's `/.well-known/matrix/client` config:
 
 The settings above were first proposed under a `im.vector.riot.e2ee` key, which
 is now deprecated. Element will check for either key, preferring
-`im.vector.e2ee` if both exist.
+`io.element.e2ee` if both exist.

--- a/docs/e2ee.md
+++ b/docs/e2ee.md
@@ -7,10 +7,30 @@ For private room creation, Element will default to encryption on but give you th
 
 Set the following on your homeserver's
 `/.well-known/matrix/client` config:
+
 ```json
 {
   "im.vector.e2ee": {
     "default": false
+  }
+}
+```
+
+# Secure backup
+
+By default, Element strongly encourages (but does not require) users to set up
+Secure Backup so that cross-signing identity key and message keys can be
+recovered in case of a disaster where you lose access to all active devices.
+
+## Requiring secure backup
+
+To require Secure Backup to be configured before Element can be used, set the
+following on your homeserver's `/.well-known/matrix/client` config:
+
+```json
+{
+  "im.vector.e2ee": {
+    "secureBackupRequired": true
   }
 }
 ```

--- a/docs/e2ee.md
+++ b/docs/e2ee.md
@@ -9,8 +9,14 @@ Set the following on your homeserver's
 `/.well-known/matrix/client` config:
 ```json
 {
-  "im.vector.riot.e2ee": {
+  "im.vector.e2ee": {
     "default": false
   }
 }
 ```
+
+# Compatibility
+
+The settings above were first proposed under a `im.vector.riot.e2ee` key, which
+is now deprecated. Element will check for either key, preferring
+`im.vector.e2ee` if both exist.


### PR DESCRIPTION
This adds notes on configuring the new `.well-known` setting to require Element
users to set up secure backup before continuing into the app.

Part of https://github.com/vector-im/element-web/issues/14954
Used by https://github.com/matrix-org/matrix-react-sdk/pull/5130