### PR TITLE
Support usage of Jitsi widgets with "openidtoken-jwt" auth 

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "browser-request": "^0.3.3",
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
+    "jsrsasign": "^9.1.5",
     "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
     "matrix-react-sdk": "github:matrix-org/matrix-react-sdk#develop",
     "olm": "https://packages.matrix.org/npm/olm/olm-3.1.4.tgz",

--- a/src/vector/jitsi/index.html
+++ b/src/vector/jitsi/index.html
@@ -11,7 +11,9 @@
         <div class="joinConferencePrompt">
             <!-- TODO: i18n -->
             <h2>Jitsi Video Conference</h2>
-            <button type="button" id="joinButton">Join Conference</button>
+            <div id="widgetActionContainer">
+                <button type="button" id="joinButton">Join Conference</button>
+            </div>
         </div>
     </div>
 </div>

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -221,7 +221,7 @@ function joinConference() { // event handler bound in HTML
         },
         jwt: undefined,
     };
-    if (jitsiAuth === 'penidtoken-jwt') {
+    if (jitsiAuth === 'openidtoken-jwt') {
         options.jwt = createJWTToken();
     }
     const meetApi = new JitsiMeetExternalAPI(jitsiDomain, options);

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -189,7 +189,6 @@ function createJWTToken() {
     // Sign JWT
     // The secret string here is irrelevant, we're only using the JWT
     // to transport data to Prosody in the Jitsi stack.
-    // See TODO add link
     return KJUR.jws.JWS.sign(
         'HS256',
         JSON.stringify(header),

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -174,8 +174,11 @@ function joinConference() { // event handler bound in HTML
 
     switchVisibleContainers();
 
-    // noinspection JSIgnoredPromiseFromCall
-    if (widgetApi) widgetApi.setAlwaysOnScreen(true); // ignored promise because we don't care if it works
+    if (widgetApi) {
+        // ignored promise because we don't care if it works
+        // noinspection JSIgnoredPromiseFromCall
+        widgetApi.setAlwaysOnScreen(true);
+    }
 
     console.warn(
         "[Jitsi Widget] The next few errors about failing to parse URL parameters are fine if " +
@@ -204,8 +207,11 @@ function joinConference() { // event handler bound in HTML
     meetApi.on("readyToClose", () => {
         switchVisibleContainers();
 
-        // noinspection JSIgnoredPromiseFromCall
-        if (widgetApi) widgetApi.setAlwaysOnScreen(false); // ignored promise because we don't care if it works
+        if (widgetApi) {
+            // ignored promise because we don't care if it works
+            // noinspection JSIgnoredPromiseFromCall
+            widgetApi.setAlwaysOnScreen(false);
+        }
 
         document.getElementById("jitsiContainer").innerHTML = "";
     });

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -125,6 +125,7 @@ function onWidgetMessage(msg) {
             await widgetApi.waitReady();
             await widgetApi.setAlwaysOnScreen(false); // start off as detachable from the screen
 
+            // See https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification
             if (jitsiAuth === 'openidtoken-jwt') {
                 window.addEventListener('message', onWidgetMessage);
                 widgetApi.callAction(
@@ -160,7 +161,7 @@ function switchVisibleContainers() {
 /**
  * Create a JWT token fot jitsi openidtoken-jwt auth
  *
- * See TODO add link
+ * See https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification
  */
 function createJWTToken() {
     // Header

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -61,6 +61,7 @@ function processOpenIDMessage(msg) {
             break;
         case 'blocked':
             console.warn('OpenID credentials request was blocked by user.');
+            document.getElementById("widgetActionContainer").innerText = "Failed to load Jitsi widget";
             break;
         default:
            // nothing to do
@@ -142,8 +143,7 @@ function onWidgetMessage(msg) {
         }
     } catch (e) {
         console.error("Error setting up Jitsi widget", e);
-        document.getElementById("jitsiContainer").innerText = "Failed to load Jitsi widget";
-        switchVisibleContainers();
+        document.getElementById("widgetActionContainer").innerText = "Failed to load Jitsi widget";
     }
 })();
 

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -20,7 +20,7 @@ require("./index.scss");
 import * as qs from 'querystring';
 import {Capability, KnownWidgetActions, WidgetApi} from 'matrix-react-sdk/src/widgets/WidgetApi';
 import {KJUR} from 'jsrsasign';
-import {objectClone} from 'matrix-react-sdk/lib/utils/objects';
+import {objectClone} from 'matrix-react-sdk/src/utils/objects';
 
 // Dev note: we use raw JS without many dependencies to reduce bundle size.
 // We do not need all of React to render a Jitsi conference.

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -167,8 +167,10 @@ function createJWTToken() {
     const header = {alg: 'HS256', typ: 'JWT'};
     // Payload
     const payload = {
-        // TODO change this to refer to spec?
-        iss: 'app_id',
+        // As per Jitsi token auth, `iss` needs to be set to something agreed between
+        // JWT generating side and Prosody config. Since we have no configuration for
+        // the widgets, we can't set one anywhere. Using the Jitsi domain here probably makes sense.
+        iss: jitsiDomain,
         sub: jitsiDomain,
         aud: `https://${jitsiDomain}`,
         room: "*",

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -132,7 +132,7 @@ function onWidgetMessage(msg) {
                 widgetApi.callAction(
                     KnownWidgetActions.GetOpenIDCredentials,
                     {},
-                    (response) => {console.log(response);},
+                    () => {},
                 );
             } else {
                 enableJoinButton();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6914,6 +6914,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsrsasign@^9.1.5:
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-9.1.5.tgz#fe286425d2c05b2d0865d24ded53e34b12abd2ca"
+  integrity sha512-iJLF8FvZHlwyQudrRtQomHj1HdPAcM8QSRTt0FJo8a6iFgaGCpKUrE7lWyELpAjrFs8jUC/Azc0vfhlj3yqHPQ==
+
 jsx-ast-utils@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.3.0.tgz#edd727794ea284d7fda575015ed1b0cde0289ab6"


### PR DESCRIPTION
This PR adds the Element Web parts for supporting Synapse OpenID token based auth for Jitsi widgets. This auth enables locking Jitsi widgets to particular homeserver users and rooms. The whole flow is described here: https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification

The auth flow is only used when the Jitsi server has a well-known file indicating the requirement of auth.

Blocked by:
* React-SDK PR side for the Jitsi widget code PR: https://github.com/matrix-org/matrix-react-sdk/pull/5173
* https://github.com/matrix-org/matrix-react-sdk/pull/5172 

Replaces #15111 (to match react-sdk branch)