### PR TITLE
Remove references to Travis CI

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
-Contributing code to Riot
-=========================
+Contributing code to Element
+============================
 
-Riot follows the same pattern as https://github.com/matrix-org/matrix-js-sdk/blob/master/CONTRIBUTING.rst.
+Element follows the same pattern as https://github.com/matrix-org/matrix-js-sdk/blob/master/CONTRIBUTING.rst.

--- a/scripts/fetch-develop.deps.sh
+++ b/scripts/fetch-develop.deps.sh
@@ -70,7 +70,6 @@ function dodep() {
 
 ##############################
 
-echo -en 'travis_fold:start:matrix-js-sdk\r'
 echo 'Setting up matrix-js-sdk'
 
 dodep matrix-org matrix-js-sdk
@@ -83,11 +82,8 @@ popd
 
 yarn link matrix-js-sdk
 
-echo -en 'travis_fold:end:matrix-js-sdk\r'
-
 ##############################
 
-echo -en 'travis_fold:start:matrix-react-sdk\r'
 echo 'Setting up matrix-react-sdk'
 
 dodep matrix-org matrix-react-sdk
@@ -100,8 +96,6 @@ yarn build
 popd
 
 yarn link matrix-react-sdk
-
-echo -en 'travis_fold:end:matrix-react-sdk\r'
 
 ##############################
 


### PR DESCRIPTION
Also cleans up a Riot reference as well

Part of https://github.com/vector-im/element-web/issues/15098