### PR TITLE
Rebrand the webpack pipeline for Element

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build:bundle-stats": "webpack --progress --bail --mode production --json > webpack-stats.json",
     "build:types": "tsc --emitDeclarationOnly --jsx react",
     "dist": "scripts/package.sh",
-    "start": "concurrently --kill-others-on-fail --prefix \"{time} [{name}]\" -n reskindex,reskindex-react,res,riot-js \"yarn reskindex:watch\" \"yarn reskindex:watch-react\" \"yarn start:res\" \"yarn start:js\"",
+    "start": "concurrently --kill-others-on-fail --prefix \"{time} [{name}]\" -n reskindex,reskindex-react,res,element-js \"yarn reskindex:watch\" \"yarn reskindex:watch-react\" \"yarn start:res\" \"yarn start:js\"",
     "start:res": "yarn build:jitsi && node scripts/copy-res.js -w",
     "start:js": "webpack-dev-server --host=0.0.0.0 --output-filename=bundles/_dev_/[name].js --output-chunk-filename=bundles/_dev_/[name].js -w --progress --mode development",
     "lint": "yarn lint:types && yarn lint:js && yarn lint:style",


### PR DESCRIPTION
This just fixes logging when using `yarn start` to have the right prefix