### PR TITLE
Give the Jitsi widget an icon to help with discovery

### DIFF
--- a/src/vector/jitsi/index.html
+++ b/src/vector/jitsi/index.html
@@ -10,6 +10,7 @@
     <div class="joinConferenceFloating">
         <div class="joinConferencePrompt">
             <span class="icon"><!-- managed by CSS --></span>
+            <!-- TODO: i18n -->
             <h2>Jitsi Video Conference</h2>
             <div id="widgetActionContainer">
                 <button type="button" id="joinButton">Join Conference</button>

--- a/src/vector/jitsi/index.html
+++ b/src/vector/jitsi/index.html
@@ -9,7 +9,7 @@
 <div id="joinButtonContainer">
     <div class="joinConferenceFloating">
         <div class="joinConferencePrompt">
-            <!-- TODO: i18n -->
+            <span class="icon"><!-- managed by CSS --></span>
             <h2>Jitsi Video Conference</h2>
             <div id="widgetActionContainer">
                 <button type="button" id="joinButton">Join Conference</button>

--- a/src/vector/jitsi/index.scss
+++ b/src/vector/jitsi/index.scss
@@ -23,10 +23,11 @@ limitations under the License.
     src: url('~matrix-react-sdk/res/fonts/Nunito/Nunito-Regular.ttf') format('truetype');
 }
 
+$fg-color: #edf3ff;
 body {
     font-family: Nunito, Arial, Helvetica, sans-serif;
     background-color: #181b21;
-    color: #edf3ff;
+    color: $fg-color;
 }
 
 body, html {
@@ -72,4 +73,23 @@ body, html {
     color: #ffffff;
     background-color: #03b381;
     border: 0;
+}
+
+.icon {
+    $icon-size: 42px;
+    margin-top: -$icon-size; // to visually center the form
+
+    &::before {
+        content: '';
+        background-size: contain;
+        background-color: $fg-color;
+        mask-repeat: no-repeat;
+        mask-position: center;
+        mask-image: url("~matrix-react-sdk/res/img/element-icons/call/video-call.svg");
+        mask-size: $icon-size;
+        display: block;
+        width: $icon-size;
+        height: $icon-size;
+        margin: 0 auto; // center
+    }
 }


### PR DESCRIPTION
We think users will be expecting to follow a series of icons into their conference, so we'll remind them here of what is going on with a giant icon.

This does not change depending on the call type because the jitsi widget doesn't understand the call type anyways - it's always a video conference.

![image](https://user-images.githubusercontent.com/1190097/94589957-30d10080-0243-11eb-8916-97f688231eb5.png)
