### PR TITLE
Remove riot-bot from sample config

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -35,7 +35,6 @@
             "matrix.org"
         ]
     },
-    "welcomeUserId": "@riot-bot:matrix.org",
     "piwik": {
         "url": "https://piwik.riot.im/",
         "whitelistedHSUrls": ["https://matrix.org"],


### PR DESCRIPTION
`riot-bot` is no longer recommended these days, and it causes confusion to have
in the sample config.

Fixes https://github.com/vector-im/element-web/issues/15357