### PR TITLE
Use HTTPS_PROXY environment variable for downloading external_api.min…

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "postcss-strip-inline-comments": "^0.1.5",
     "rimraf": "^2.4.3",
     "shell-escape": "^0.2.0",
+    "simple-proxy-agent": "^1.1.0",
     "stylelint": "^12.0.1",
     "terser-webpack-plugin": "^2.3.0",
     "typescript": "^3.7.3",

--- a/scripts/build-jitsi.js
+++ b/scripts/build-jitsi.js
@@ -7,6 +7,7 @@ const fs = require("fs");
 const path = require("path");
 const mkdirp = require("mkdirp");
 const fetch = require("node-fetch");
+const ProxyAgent = require("simple-proxy-agent");
 
 console.log("Making webapp directory");
 mkdirp.sync("webapp");
@@ -14,7 +15,13 @@ mkdirp.sync("webapp");
 // curl -s https://jitsi.riot.im/libs/external_api.min.js > ./webapp/jitsi_external_api.min.js
 console.log("Downloading Jitsi script");
 const fname = path.join("webapp", "jitsi_external_api.min.js");
-fetch("https://jitsi.riot.im/libs/external_api.min.js").then(res => {
+
+const options = {};
+if (process.env.HTTPS_PROXY) {
+   options.agent = new ProxyAgent(process.env.HTTPS_PROXY, { tunnel : true } );
+}
+
+fetch("https://jitsi.riot.im/libs/external_api.min.js", options).then(res => {
    const stream = fs.createWriteStream(fname);
    return new Promise((resolve, reject) => {
        res.body.pipe(stream);

--- a/scripts/build-jitsi.js
+++ b/scripts/build-jitsi.js
@@ -18,7 +18,7 @@ const fname = path.join("webapp", "jitsi_external_api.min.js");
 
 const options = {};
 if (process.env.HTTPS_PROXY) {
-   options.agent = new ProxyAgent(process.env.HTTPS_PROXY, { tunnel : true } );
+   options.agent = new ProxyAgent(process.env.HTTPS_PROXY, {tunnel: true});
 }
 
 fetch("https://jitsi.riot.im/libs/external_api.min.js", options).then(res => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11286,6 +11286,13 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-proxy-agent@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/simple-proxy-agent/-/simple-proxy-agent-1.1.0.tgz#974cd1130dd32554775e2d4caeb70d701f7ca8b3"
+  integrity sha512-amJaLagzNELaNNB2UXdXiORVbbU/RC4yRwtGvF4cttJheTm4JvL2fZ1SfuLU952XC7TLamYdgzzJtWUbGM6Jcw==
+  dependencies:
+    socks "^2.3.2"
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -11385,6 +11392,14 @@ socks-proxy-agent@^4.0.0:
   dependencies:
     agent-base "~4.2.1"
     socks "~2.3.2"
+
+socks@^2.3.2:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.4.4.tgz#f1a3382e7814ae28c97bb82a38bc1ac24b21cca2"
+  integrity sha512-7LmHN4IHj1Vpd/k8D872VGCHJ6yIVyeFkfIBExRmGPYQ/kdUkpdg9eKh9oOzYYYKQhuxavayJHTnmBG+EzluUA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
 
 socks@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
At the moment running 'yarn dist' fails, if a proxy is neccessary for https downloads.
This PR enables the build-jitsi.js script to consider the environment variable HTTPS_PROXY.
If there is something wrong with my patch, please let me know as i am not a js dev...

Signed-off-by: Sebastian Denz <denz@gonicus.de>