### PR TITLE
Skip editor confirmation of upgrades

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -38,9 +38,7 @@ do
             echo "Upgrading $i to $latestver..."
             yarn add -E $i@$latestver
             git add -u
-            # The `-e` flag opens the editor and gives you a chance to check
-            # the upgrade for correctness.
-            git commit -m "Upgrade $i to $latestver" -e
+            git commit -m "Upgrade $i to $latestver"
         fi
     fi
 done


### PR DESCRIPTION
In practice, the upgrades are always fine, and this editor prompt just adds
delays.