### PR TITLE
Rename Docker repo in docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:12 as builder
 
 # Support custom branches of the react-sdk and js-sdk. This also helps us build
-# images of riot-web develop.
+# images of element-web develop.
 ARG USE_CUSTOM_SDKS=false
 ARG REACT_SDK_REPO="https://github.com/matrix-org/matrix-react-sdk.git"
 ARG REACT_SDK_BRANCH="master"

--- a/README.md
+++ b/README.md
@@ -129,14 +129,14 @@ Running from Docker
 The Docker image can be used to serve element-web as a web server. The easiest way to use
 it is to use the prebuilt image:
 ```bash
-docker run -p 80:80 vectorim/riot-web
+docker run -p 80:80 vectorim/element-web
 ```
 
 To supply your own custom `config.json`, map a volume to `/app/config.json`. For example,
 if your custom config was located at `/etc/element-web/config.json` then your Docker command
 would be:
 ```bash
-docker run -p 80:80 -v /etc/element-web/config.json:/app/config.json vectorim/riot-web
+docker run -p 80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
 ```
 
 To build the image yourself:


### PR DESCRIPTION
We now have a Docker repo named `element-web`, so this updates docs to match.

Fixes https://github.com/vector-im/element-web/issues/14930