### PR TITLE
Add Docker Build Workflow

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -1,0 +1,84 @@
+name: docker-buildx
+
+on:
+  pull_request:
+    branches: develop
+  push:
+    branches: develop
+    tags:
+      - v*
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Prepare
+        id: prepare
+        run: |
+          DOCKER_IMAGE=mattcen/riot-web
+          VERSION=develop
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+
+          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+          fi
+
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=buildx_args::\
+            --build-arg VERSION=${VERSION} \
+            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+            --build-arg VCS_REF=${GITHUB_SHA::8} \
+            ${TAGS} --file Dockerfile .
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      -
+        name: Docker Buildx (build amd64)
+        run: |
+          DOCKER_PLATFORMS=linux/amd64
+          docker buildx build --output "type=image,push=false" --platform ${DOCKER_PLATFORMS} ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Buildx (build arm64)
+        run: |
+          DOCKER_PLATFORMS=linux/arm64
+          docker buildx build --output "type=image,push=false" --platform ${DOCKER_PLATFORMS} ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Buildx (build armv7)
+        run: |
+          DOCKER_PLATFORMS=linux/arm/v7
+          docker buildx build --output "type=image,push=false" --platform ${DOCKER_PLATFORMS} ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Login to DockerHub
+        if: success() && github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Docker Buildx (push)
+        if: success() && github.event_name != 'pull_request'
+        run: |
+          DOCKER_PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64
+          docker buildx build --output "type=image,push=true" --platform ${DOCKER_PLATFORMS} ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Inspect image
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          docker buildx imagetools inspect ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ WORKDIR /src
 
 COPY . /src
 RUN dos2unix /src/scripts/docker-link-repos.sh && bash /src/scripts/docker-link-repos.sh
-RUN yarn --network-timeout=100000 install
-RUN yarn build
+RUN yarn --max_old_space_size=4096 --network-timeout=100000 install
+RUN yarn --max_old_space_size=4096 build
 
 # Copy the config now so that we don't create another layer in the app image
 RUN cp /src/config.sample.json /src/webapp/config.json

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,41 @@
+## Builder
+#FROM --platform=linux/arm/v7 node:12 as builder
+#
+## Support custom branches of the react-sdk and js-sdk. This also helps us build
+## images of riot-web develop.
+#ARG USE_CUSTOM_SDKS=false
+#ARG REACT_SDK_REPO="https://github.com/matrix-org/matrix-react-sdk.git"
+#ARG REACT_SDK_BRANCH="master"
+#ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
+#ARG JS_SDK_BRANCH="master"
+#
+#RUN apt-get update && apt-get install -y git dos2unix \
+## These packages are required for building Canvas on architectures like Arm
+## See https://www.npmjs.com/package/canvas#compiling
+#  build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+#
+#WORKDIR /src
+#
+#COPY . /src
+#RUN dos2unix /src/scripts/docker-link-repos.sh && bash /src/scripts/docker-link-repos.sh
+#
+#RUN yarn --network-timeout=100000 install
+#RUN yarn build
+#
+## Copy the config now so that we don't create another layer in the app image
+#RUN cp /src/config.sample.json /src/webapp/config.json
+#
+## Ensure we populate the version file
+#RUN dos2unix /src/scripts/docker-write-version.sh && bash /src/scripts/docker-write-version.sh
+
+
+# App
+FROM --platform=linux/arm/v7 nginx:alpine
+
+COPY --from=mattcen/riot-web:v1.7.7 /app /app
+
+# Insert wasm type into Nginx mime.types file so they load correctly.
+RUN sed -i '3i\ \ \ \ application/wasm wasm\;' /etc/nginx/mime.types
+
+RUN rm -rf /usr/share/nginx/html \
+ && ln -s /app /usr/share/nginx/html


### PR DESCRIPTION
This PR sets up a GitHub Workflow that builds Docker images for amd64, armv7, and arm64, and then pushes the image to Docker Hub.

Building Element web for arm takes a *long* time, so needing to build it manually on my Raspberry Pi every time there's a new release isn't a straightforward task, so having a pre-build image would be ideal.

If deemed sufficiently and worthy of approval, this would deprecate the automatic building that is currently happening on Docker hub.

I've set up the build script to build each architecture together (steps `Docker Buildx (build amd64)`, `Docker Buildx (build arm64)`, and `Docker Buildx (build armv7)`), and then pull them all together with `Docker Buildx (push)`. I did it this way, rather than build them all at once, because I don't think the build instance can manage doing a parallel build.

I ran into a lot of problems getting this built in the past, because unlike for amd64, other architectures need to build a bunch of platform-dependent Node modules because pre-built binaries don't exist for the non-amd64 builds on `npm`. The problem I kept hitting was that the step `RUN yarn --max_old_space_size=4096 build` (or possibly the `install` beforehand), kept dying with a segmentation fault, which searching suggested was due to a shortage of memory while trying to generate the webpack.

This seems to be all working now, but it's possible more testing is warranted, in case it's a little fragile.