### PR TITLE
Stop publishing Element to NPM

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -43,7 +43,7 @@ do
     fi
 done
 
-./node_modules/matrix-js-sdk/release.sh -u vector-im -z "$orig_args"
+./node_modules/matrix-js-sdk/release.sh -n -z "$orig_args"
 
 release="${1#v}"
 tag="v${release}"


### PR DESCRIPTION
It generally does not make much sense to publish an entire application like this
to NPM, so we've agreed to stop doing so going forward.

Fixes https://github.com/vector-im/element-web/issues/14902