### PR TITLE
Rebrand package name and other details

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -19,7 +19,7 @@ module.exports = {
         "at-rule-no-unknown": null,
         "no-descending-specificity": null,
         "scss/at-rule-no-unknown": [true, {
-            // https://github.com/vector-im/riot-web/issues/10544
+            // https://github.com/vector-im/element-web/issues/10544
             "ignoreAtRules": ["define-mixin"],
         }],
     }

--- a/docs/app-load.md
+++ b/docs/app-load.md
@@ -74,7 +74,7 @@ Key:
 
 Notes:
 + A task begins when all its dependencies (arrows going into it) are fulfilled.
-+ The success of setting up rageshake is never asserted, riot-web has a fallback path for running without IDB (and thus rageshake).
++ The success of setting up rageshake is never asserted, element-web has a fallback path for running without IDB (and thus rageshake).
 + Everything is awaited to be settled before the Modernizr check, to allow it to make use of things like i18n if they are successful.
 
 Underlying dependencies:

--- a/docs/config.md
+++ b/docs/config.md
@@ -152,7 +152,7 @@ decentralised.
 Desktop app configuration
 =========================
 
-See https://github.com/vector-im/riot-desktop#user-specified-configjson
+See https://github.com/vector-im/element-desktop#user-specified-configjson
 
 UI Features
 ===========

--- a/docs/jitsi.md
+++ b/docs/jitsi.md
@@ -40,7 +40,7 @@ should start a new conference on your Jitsi server.
 domain will appear later in the URL as a configuration parameter.
 
 **Hint**: If you want everyone on your homeserver to use the same Jitsi server by
-default, and you are using riot-web 1.6 or newer, set the following on your homeserver's 
+default, and you are using element-web 1.6 or newer, set the following on your homeserver's 
 `/.well-known/matrix/client` config:
 ```json
 {

--- a/docs/review.md
+++ b/docs/review.md
@@ -43,7 +43,7 @@ When reviewing code, here are some things we look for and also things we avoid:
 
 ### Workflow
 
-* Authors should request review from the riot-web team by default (if someone on
+* Authors should request review from the element-web team by default (if someone on
   the team is clearly the expert in an area, a direct review request to them may
   be more appropriate)
 * Reviewers should remove the team review request and request review from

--- a/docs/skinning thoughts.md
+++ b/docs/skinning thoughts.md
@@ -52,7 +52,7 @@ other changes:
     - skins/vector/themes/foo/css
     - skins/vector/themes/foo/img
     - skins/vector/themes/foo/fonts
-  - ideally riot-web would contain almost nothing but skins/vector directory. 
+  - ideally element-web would contain almost nothing but skins/vector directory. 
   - ability to entirely replace CSS rather than override it for a given theme
     - e.g. if we replace `Login.js` with `StatusLogin.js`, then we should similarly be able to replace `_Login.scss` with `_StatusLogin.scss`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "riot-web",
-  "productName": "Riot",
+  "name": "element-web",
   "version": "1.7.14",
   "description": "A feature-rich client for Matrix.org",
   "author": "New Vector Ltd.",

--- a/scripts/issues-no-state.pl
+++ b/scripts/issues-no-state.pl
@@ -18,7 +18,7 @@ my $gh = Net::GitHub->new(
     login => 'ara4n', pass => read_password("github password: "),
 );
 
-$gh->set_default_user_repo('vector-im', 'riot-web');
+$gh->set_default_user_repo('vector-im', 'element-web');
 
 #my @issues = $gh->issue->repos_issues({ state => 'all', milestone => 3 });
 my @issues = $gh->issue->repos_issues({ state => 'all' });

--- a/src/vector/init.tsx
+++ b/src/vector/init.tsx
@@ -126,7 +126,7 @@ export async function loadSkin() {
             /* webpackPreload: true */
             "matrix-react-sdk"),
         import(
-            /* webpackChunkName: "riot-web-component-index" */
+            /* webpackChunkName: "element-web-component-index" */
             /* webpackPreload: true */
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore - this module is generated so may fail lint
@@ -143,7 +143,7 @@ export async function loadTheme() {
 export async function loadApp(fragParams: {}) {
     // load app.js async so that its code is not executed immediately and we can catch any exceptions
     const module = await import(
-        /* webpackChunkName: "riot-web-app" */
+        /* webpackChunkName: "element-web-app" */
         /* webpackPreload: true */
         "./app");
     window.matrixChat = ReactDOM.render(await module.loadApp(fragParams),

--- a/src/vector/jitsi/index.scss
+++ b/src/vector/jitsi/index.scss
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO: Match the user's theme: https://github.com/vector-im/riot-web/issues/12794
+// TODO: Match the user's theme: https://github.com/vector-im/element-web/issues/12794
 
 @font-face {
     font-family: 'Nunito';

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -116,7 +116,7 @@ let meetApi: any; // JitsiMeetExternalAPI
                 console.log("Got OpenID Connect token");
             }
 
-            // TODO: register widgetApi listeners for PTT controls (https://github.com/vector-im/riot-web/issues/12795)
+            // TODO: register widgetApi listeners for PTT controls (https://github.com/vector-im/element-web/issues/12795)
 
             widgetApi.on(`action:${ElementWidgetActions.HangupCall}`,
                 (ev: CustomEvent<IWidgetApiRequest>) => {

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -239,7 +239,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
 
         // try to flush the rageshake logs to indexeddb before quit.
         ipcRenderer.on('before-quit', function() {
-            console.log('riot-desktop closing');
+            console.log('element-desktop closing');
             rageshake.flush();
         });
 

--- a/src/vector/platform/VectorBasePlatform.ts
+++ b/src/vector/platform/VectorBasePlatform.ts
@@ -40,7 +40,7 @@ export default abstract class VectorBasePlatform extends BasePlatform {
     /**
      * Delay creating the `Favicon` instance until first use (on the first notification) as
      * it uses canvas, which can trigger a permission prompt in Firefox's resist fingerprinting mode.
-     * See https://github.com/vector-im/riot-web/issues/9605.
+     * See https://github.com/vector-im/element-web/issues/9605.
      */
     get favicon() {
         if (this._favicon) {

--- a/src/vector/rageshakesetup.ts
+++ b/src/vector/rageshakesetup.ts
@@ -38,7 +38,7 @@ export function initRageshake() {
             "Meatball menu → Settings → Blackboxing → Add /rageshake\\.js$");
 
         window.addEventListener('beforeunload', (e) => {
-            console.log('riot-web closing');
+            console.log('element-web closing');
             // try to flush the logs to indexeddb
             rageshake.flush();
         });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -249,7 +249,7 @@ module.exports = (env, argv) => {
                 },
                 {
                     // cache-bust languages.json file placed in
-                    // riot-web/webapp/i18n during build by copy-res.js
+                    // element-web/webapp/i18n during build by copy-res.js
                     test: /\.*languages.json$/,
                     type: "javascript/auto",
                     loader: 'file-loader',


### PR DESCRIPTION
Now that we aren't publishing the app to NPM any more, we can fix basic details like the package name.

This also includes some other misc. rebrandings as well.