### PR TITLE
webplatform: Fix notification closing

### DIFF
--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -89,6 +89,8 @@ export default class WebPlatform extends VectorBasePlatform {
             window.focus();
             notification.close();
         };
+
+        return notification;
     }
 
     _getVersion(): Promise<string> {


### PR DESCRIPTION
After a notification arrives, when the user focuses on element, the
notification never goes away (unless directly interacted with), this was a bug.

displayNotification was never returning the notification handle, which means
that matrix-react-sdk later on had no way to .close it.

Closes #16026, please see that bug for more info about following the code flow that lead to this.

Signed-off-by: Alexandru M Stan <alex@hypertriangle.com>