### PR TITLE
Skip the service worker for Electron

### DIFF
--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -29,11 +29,6 @@ require('katex/dist/katex.css');
 import {parseQsFromFragment} from "./url_utils";
 import './modernizr';
 
-// load service worker if available on this platform
-if (!window.electron && 'serviceWorker' in navigator) {
-    navigator.serviceWorker.register('sw.js');
-}
-
 async function settled(...promises: Array<Promise<any>>) {
     for (const prom of promises) {
         try {

--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -30,7 +30,7 @@ import {parseQsFromFragment} from "./url_utils";
 import './modernizr';
 
 // load service worker if available on this platform
-if ('serviceWorker' in navigator) {
+if (!window.electron && 'serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js');
 }
 

--- a/src/vector/init.tsx
+++ b/src/vector/init.tsx
@@ -49,6 +49,8 @@ export function preparePlatform() {
         console.log("Using Web platform");
         PlatformPeg.set(new WebPlatform());
     }
+    // Register service worker if available on this platform
+    PlatformPeg.get().registerServiceWorker();
 }
 
 export async function loadConfig() {

--- a/src/vector/init.tsx
+++ b/src/vector/init.tsx
@@ -49,8 +49,6 @@ export function preparePlatform() {
         console.log("Using Web platform");
         PlatformPeg.set(new WebPlatform());
     }
-    // Register service worker if available on this platform
-    PlatformPeg.get().registerServiceWorker();
 }
 
 export async function loadConfig() {

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -38,6 +38,12 @@ export default class WebPlatform extends VectorBasePlatform {
         return 'Web Platform'; // no translation required: only used for analytics
     }
 
+    registerServiceWorker(): void {
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js');
+        }
+    }
+
     /**
      * Returns true if the platform supports displaying
      * notifications, otherwise false.

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -34,14 +34,16 @@ const POKE_RATE_MS = 10 * 60 * 1000; // 10 min
 export default class WebPlatform extends VectorBasePlatform {
     private runningVersion: string = null;
 
-    getHumanReadableName(): string {
-        return 'Web Platform'; // no translation required: only used for analytics
-    }
-
-    registerServiceWorker(): void {
+    constructor() {
+        super();
+        // Register service worker if available on this platform
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('sw.js');
         }
+    }
+
+    getHumanReadableName(): string {
+        return 'Web Platform'; // no translation required: only used for analytics
     }
 
     /**


### PR DESCRIPTION
At the moment, there's no point in installing the empty service worker on
Electron.

Fixes https://github.com/vector-im/element-web/issues/16008
Depends on https://github.com/matrix-org/matrix-react-sdk/pull/5545