### PR TITLE
Go to login instead of registration after email validation

### DIFF
--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -99,7 +99,7 @@ function makeRegistrationUrl(params: object) {
             window.location.protocol + '//' +
             window.location.host +
             window.location.pathname +
-            '#/register'
+            '#/login'
         );
     }
 


### PR DESCRIPTION
I'm using `ma1sd` as an identity server. When a new user registers and clicks on the email verification link he is redirected to `#/register`. It would be more useful when he is redirected to `#/login` instead, because he already completed the registration.

According to [this spec](https://matrix.org/docs/spec/identity_service/r0.3.0#post-matrix-identity-v2-validate-email-requesttoken) the redirection url is the `next_link` parameter of this route: `/_matrix/identity/v2/validate/email/requestToken`

[This](https://github.com/matrix-org/matrix-js-sdk/blob/2d7f5ae27955ba98e7e265d0c4013ec69d9d3d63/src/client.js#L4290-L4301) is the function that makes that API call and [that](https://github.com/matrix-org/matrix-react-sdk/blob/3940eab165021fc643e37bc10091d75ccdef1f47/src/components/structures/auth/Registration.tsx#L260-L264) creates the `next_link` parameter. In the end [this function](https://github.com/vector-im/element-web/blob/e0e29996e0ee61013d8a1ec6b65683980f0147f8/src/vector/app.tsx#L93-L104) creates the `next_link` parameter for the email verification link and should in my opinion therefore be change from `#/register` to `#/login`