### PR TITLE
Fix develop Docker builds

### DIFF
--- a/scripts/docker-link-repos.sh
+++ b/scripts/docker-link-repos.sh
@@ -32,6 +32,7 @@ cd react-sdk
 yarn link
 yarn link matrix-js-sdk
 yarn --network-timeout=100000 install
+yarn reskindex
 cd ../
 
 echo "Setting up element-web with react-sdk and js-sdk packages"


### PR DESCRIPTION
An extra step is needed for develop Docker builds after recent build process changes. This was regressed by https://github.com/vector-im/element-web/pull/15999.

Fixes https://github.com/vector-im/element-web/issues/16119