### PR TITLE
Move to newer base image for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM node:12 as builder
+FROM node:14-buster as builder
 
 # Support custom branches of the react-sdk and js-sdk. This also helps us build
 # images of element-web develop.


### PR DESCRIPTION
This updates to Node 14 (current LTS) as well as moving from Debian Stretch to
Buster for the base OS. The Debian upgrade brings along a newer Python 3.8,
which is actively supported.