### PR TITLE
Fix Electron type merging

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -39,16 +39,18 @@ declare global {
         matrixChat: ReturnType<Renderer>;
 
         // electron-only
-        electron: {
-            on(channel: ElectronChannel, listener: (event: Event, ...args: any[]) => void): void;
-            send(channel: ElectronChannel, ...args: any[]): void;
-        }
+        electron?: Electron;
 
         // opera-only
-        opera: any;
+        opera?: any;
 
         // https://developer.mozilla.org/en-US/docs/Web/API/InstallTrigger
         InstallTrigger: any;
+    }
+
+    interface Electron {
+        on(channel: ElectronChannel, listener: (event: Event, ...args: any[]) => void): void;
+        send(channel: ElectronChannel, ...args: any[]): void;
     }
 
     interface Navigator {


### PR DESCRIPTION
This changes to an interface for Electron types so that other layers can merge
in further APIs as needed, such as the JS SDK.

Related to https://github.com/matrix-org/matrix-js-sdk/pull/1594