### PR TITLE
Disable Countly

### DIFF
--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -18,10 +18,6 @@
         "siteId": 1,
         "policyUrl": "https://element.io/cookie-policy"
     },
-    "countly": {
-        "url": "https://try.count.ly",
-        "appKey": "8abf1ee15646bc884556b82e5053857904264b66"
-    },
     "roomDirectory": {
         "servers": [
             "matrix.org",


### PR DESCRIPTION
The Countly experiment has ended, so this removes the configuration to enable it.