### PR TITLE
Add option for audio live streaming

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -113,6 +113,9 @@ For a good example, see https://develop.element.io/config.json.
 1. `mobileGuideToast`: Whether to show a toast a startup which nudges users on
    iOS and Android towards the native mobile apps. The toast redirects to the
    mobile guide if they accept. Defaults to false.
+1. `audioStreamUrl`: If supplied, show an option on Jitsi widgets to stream
+   audio using Jitsi's live streaming feature. This option is experimental and
+   may be removed at any time without notice.
 
 Note that `index.html` also has an og:image meta tag that is set to an image
 hosted on riot.im. This is the image used if links to your copy of Element

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -126,6 +126,22 @@ let meetApi: any; // JitsiMeetExternalAPI
                     widgetApi.transport.reply(ev.detail, {}); // ack
                 },
             );
+            widgetApi.on(`action:${ElementWidgetActions.StartLiveStream}`,
+                (ev: CustomEvent<IWidgetApiRequest>) => {
+                    if (meetApi) {
+                        meetApi.executeCommand('startRecording', {
+                            mode: 'stream',
+                            // this looks like it should be rtmpStreamKey but we may be on too old
+                            // a version of jitsi meet
+                            //rtmpStreamKey: ev.detail.data.rtmpStreamKey,
+                            youtubeStreamKey: ev.detail.data.rtmpStreamKey,
+                        });
+                        widgetApi.transport.reply(ev.detail, {}); // ack
+                    } else {
+                        widgetApi.transport.reply(ev.detail, {error: {message: "Conference not joined"}});
+                    }
+                },
+            );
         }
 
         enableJoinButton(); // always enable the button


### PR DESCRIPTION
Starts jitsi streaming to a specially configured URL so that the
jitsi server can start an audio-only stream, in combination with an
API to manage audio streams by room ID.

Requires https://github.com/matrix-org/matrix-react-sdk/pull/5707