### PR TITLE
Disable rageshake persistence if no logs would be submitted

### DIFF
--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -92,6 +92,7 @@ async function start() {
     // load init.ts async so that its code is not executed immediately and we can catch any exceptions
     const {
         rageshakePromise,
+        setupLogStorage,
         preparePlatform,
         loadOlm,
         loadConfig,
@@ -137,6 +138,9 @@ async function start() {
         const loadConfigPromise = loadConfig();
         await settled(loadConfigPromise); // wait for it to settle
         // keep initialising so that we can show any possible error with as many features (theme, i18n) as possible
+
+        // now that the config is ready, try to persist logs
+        const persistLogsPromise = setupLogStorage();
 
         // Load language after loading config.json so that settingsDefaults.language can be applied
         const loadLanguagePromise = loadLanguage();
@@ -196,6 +200,11 @@ async function start() {
         await loadSkinPromise;
         await loadThemePromise;
         await loadLanguagePromise;
+
+        // We don't care if the log persistence made it through successfully, but we do want to
+        // make sure it had a chance to load before we move on. It's prepared much higher up in
+        // the process, making this the first time we check that it did something.
+        await settled(persistLogsPromise);
 
         // Finally, load the app. All of the other react-sdk imports are in this file which causes the skinner to
         // run on the components.

--- a/src/vector/init.tsx
+++ b/src/vector/init.tsx
@@ -33,7 +33,7 @@ import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
 import SdkConfig from "matrix-react-sdk/src/SdkConfig";
 import {setTheme} from "matrix-react-sdk/src/theme";
 
-import { initRageshake } from "./rageshakesetup";
+import {initRageshake, initRageshakeStore} from "./rageshakesetup";
 
 
 export const rageshakePromise = initRageshake();
@@ -49,6 +49,14 @@ export function preparePlatform() {
         console.log("Using Web platform");
         PlatformPeg.set(new WebPlatform());
     }
+}
+
+export function setupLogStorage() {
+    if (SdkConfig.get().bug_report_endpoint_url) {
+        return initRageshakeStore();
+    }
+    console.warn("No bug report endpoint set - logs will not be persisted");
+    return Promise.resolve();
 }
 
 export async function loadConfig() {

--- a/src/vector/rageshakesetup.ts
+++ b/src/vector/rageshakesetup.ts
@@ -31,7 +31,8 @@ import SdkConfig from "matrix-react-sdk/src/SdkConfig";
 import sendBugReport from "matrix-react-sdk/src/rageshake/submit-rageshake";
 
 export function initRageshake() {
-    const prom = rageshake.init();
+    // we manually check persistence for rageshakes ourselves
+    const prom = rageshake.init(/*setUpPersistence=*/false);
     prom.then(() => {
         console.log("Initialised rageshake.");
         console.log("To fix line numbers in Chrome: " +
@@ -48,6 +49,10 @@ export function initRageshake() {
         console.error("Failed to initialise rageshake: " + err);
     });
     return prom;
+}
+
+export function initRageshakeStore() {
+    return rageshake.tryInitStorage();
 }
 
 window.mxSendRageshake = function(text: string, withLogs?: boolean) {


### PR DESCRIPTION
This also delays the persistence until later in the app startup - this is fine for the reasons listed on the partner PR: https://github.com/matrix-org/matrix-react-sdk/pull/5767

Fixes https://github.com/vector-im/element-web/issues/16694