### PR TITLE
Docker image: serve pre-compressed assets using gzip_static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN cp /src/config.sample.json /src/webapp/config.json
 # Ensure we populate the version file
 RUN dos2unix /src/scripts/docker-write-version.sh && bash /src/scripts/docker-write-version.sh
 
+# Pre-compress for gzip_static
+RUN find /src/webapp -type f \
+    \( -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.html' \
+    -o -iname '*.svg' -o -iname '*.ttf' -o -iname '*.wasm' \) \
+    -exec gzip -9 -k {} \; -exec touch -r {} {}.gz \;
 
 # App
 FROM nginx:alpine
@@ -34,7 +39,8 @@ FROM nginx:alpine
 COPY --from=builder /src/webapp /app
 
 # Insert wasm type into Nginx mime.types file so they load correctly.
-RUN sed -i '3i\ \ \ \ application/wasm wasm\;' /etc/nginx/mime.types
+RUN sed -i '3i\ \ \ \ application/wasm wasm\;' /etc/nginx/mime.types \
+ && sed -i '2i\  gzip_static on\;' /etc/nginx/conf.d/default.conf
 
 RUN rm -rf /usr/share/nginx/html \
  && ln -s /app /usr/share/nginx/html


### PR DESCRIPTION
Use `gzip_static` to reduce compressible asset sizes. Useful for Tor and other low-bandwidth networks.

**Uncompressed: 3.2 MiB**
```
% curl -sSL -D - -o /dev/null http://localhost:8001/bundles/10710025de4329178620/vendors~init.js 
HTTP/1.1 200 OK
Server: nginx/1.19.8
Date: Tue, 16 Mar 2021 21:16:36 GMT
Content-Type: application/javascript
Content-Length: 3338041
Last-Modified: Tue, 16 Mar 2021 21:03:49 GMT
Connection: keep-alive
ETag: "60511d35-32ef39"
Accept-Ranges: bytes
```

**Compressed: 891 kiB**
```
% curl -sSL -D - -o /dev/null --compressed http://localhost:8001/bundles/10710025de4329178620/vendors~init.js
HTTP/1.1 200 OK
Server: nginx/1.19.8
Date: Tue, 16 Mar 2021 21:16:05 GMT
Content-Type: application/javascript
Content-Length: 912580
Last-Modified: Tue, 16 Mar 2021 21:03:49 GMT
Connection: keep-alive
ETag: "60511d35-decc4"
Content-Encoding: gzip
```