### PR TITLE
Add reset call for corrupted event index store

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -210,6 +210,10 @@ class SeshatIndexManager extends BaseEventIndexManager {
     async deleteEventIndex(): Promise<void> {
         return this._ipcCall('deleteEventIndex');
     }
+
+    async resetEventStore(): Promise<void> {
+        return this._ipcCall('resetEventStore');
+    }
 }
 
 export default class ElectronPlatform extends VectorBasePlatform {


### PR DESCRIPTION
Fixes vector-im/element-web#14229

Related pull requests
* vector-im/element-desktop#175
* matrix-org/matrix-react-sdk#5806