### PR TITLE
Support a config option to skip login/welcome and go to SSO

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -22,9 +22,12 @@ For a good example, see https://develop.element.io/config.json.
      `default_hs_url` is specified. When multiple sources are specified, it is unclear
      which should take priority and therefore the application cannot continue.
    * As of Element 1.4.0, identity servers are optional. See [Identity servers](#identity-servers) below.
+1. `sso_immediate_redirect`: When `true`, Element will assume the default server supports SSO
+   and attempt to send the user there to continue (if they aren't already logged in). Default
+   `false`. Note that this disables all usage of the welcome page.
 1. `features`: Lookup of optional features that may be force-enabled (`true`) or force-disabled (`false`).
    When features are not listed here, their defaults will be used, and users can turn them on/off if `showLabsSettings`
-   allows them to. The available optional experimental features vary from release to release and are 
+   allows them to. The available optional experimental features vary from release to release and are
    [documented](labs.md). The feature flag process is [documented](feature-flags.md) as well.
 1. `showLabsSettings`: Shows the "labs" tab of user settings. Useful to allow users to turn on experimental features
    they might not otherwise have access to.
@@ -73,7 +76,7 @@ For a good example, see https://develop.element.io/config.json.
        not selected. By default, no home page is configured. If one is set, a
        button to access it will be shown in the top left menu.
     1. `loginForWelcome`: Overrides `welcomeUrl` to make the welcome page be the
-       same page as the login page when `true`. This effectively disables the 
+       same page as the login page when `true`. This effectively disables the
        welcome page.
 1. `defaultCountryCode`: The ISO 3166 alpha2 country code to use when showing
    country selectors, like the phone number input on the registration page.

--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -167,6 +167,10 @@ export async function loadApp(fragParams: {}) {
             idBaseUrl: config['validated_server_config'].isUrl,
         });
         PlatformPeg.get().startSingleSignOn(tempCli, "sso", `/${getScreenFromLocation(window.location).screen}`);
+
+        // We return here because startSingleSignOn() will asynchronously redirect us. We don't
+        // care to wait for it, and don't want to show any UI while we wait (not even half a welcome
+        // page). As such, just don't even bother loading the MatrixChat component.
         return;
     }
 

--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -35,6 +35,7 @@ import SdkConfig from "matrix-react-sdk/src/SdkConfig";
 
 import {parseQs, parseQsFromFragment} from './url_utils';
 import VectorBasePlatform from "./platform/VectorBasePlatform";
+import {createClient} from "matrix-js-sdk/src/matrix";
 
 let lastLocationHashSet: string = null;
 
@@ -153,6 +154,22 @@ export async function loadApp(fragParams: {}) {
 
     // Don't bother loading the app until the config is verified
     const config = await verifyServerConfig();
+
+    // Before we continue, let's see if we're supposed to do an SSO redirect
+    const [userId] = await Lifecycle.getStoredSessionOwner();
+    const hasPossibleToken = !!userId;
+    const isReturningFromSso = !!params.loginToken;
+    const autoRedirect = config['sso_immediate_redirect'] === true;
+    if (!hasPossibleToken && !isReturningFromSso && autoRedirect) {
+        console.log("Bypassing app load to redirect to SSO");
+        const tempCli = createClient({
+            baseUrl: config['validated_server_config'].hsUrl,
+            idBaseUrl: config['validated_server_config'].isUrl,
+        });
+        PlatformPeg.get().startSingleSignOn(tempCli, "sso", `/${getScreenFromLocation(window.location).screen}`);
+        return;
+    }
+
     const MatrixChat = sdk.getComponent('structures.MatrixChat');
     return <MatrixChat
         onNewScreen={onNewScreen}


### PR DESCRIPTION
For deployments which want this sort of functionality for their users. Ideal for self-hosted deployments.

No react-sdk changes needed.

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off at the end of your Pull Request (as described in CONTRIBUTING.md), or on every commit -->
