### PR TITLE
Use React production mode in CI builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,20 @@ module.exports = (env, argv) => {
         // We override this via environment variable to avoid duplicating the scripts
         // in `package.json` just for a different mode.
         argv.mode = "development";
+
+        // More and more people are using nightly build as their main client
+        // Libraries like React have a development build that is useful
+        // when working on the app but adds significant runtime overhead
+        // We want to use the React production build but not compile the whole
+        // application to productions standards
+        additionalPlugins.concat([
+            new webpack.EnvironmentPlugin({
+                "NODE_ENV": "production",
+            }),
+            new webpack.DefinePlugin({
+                "process.env.NODE_ENV": "production",
+            }),
+        ]);
     }
 
     const development = {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -138,11 +138,11 @@ module.exports = (env, argv) => {
                 // overflows (https://github.com/webpack/webpack/issues/1721), and
                 // there is no need for webpack to parse them - they can just be
                 // included as-is.
-                /highlight\.js[\\/]lib[\\/]languages/,
+                /highlight\.js[\\\/]lib[\\\/]languages/,
 
                 // olm takes ages for webpack to process, and it's already heavily
                 // optimised, so there is little to gain by us uglifying it.
-                /olm[\\/](javascript[\\/])?olm\.js$/,
+                /olm[\\\/](javascript[\\\/])?olm\.js$/,
             ],
             rules: [
                 {
@@ -184,8 +184,8 @@ module.exports = (env, argv) => {
                             loader: 'postcss-loader',
                             ident: 'postcss',
                             options: {
-                                "sourceMap": true,
-                                "plugins": () => [
+                                sourceMap: true,
+                                plugins: () => [
                                     // Note that we use significantly fewer plugins on the plain
                                     // CSS parser. If we start to parse plain CSS, we end with all
                                     // kinds of nasty problems (like stylesheets not loading).
@@ -212,7 +212,7 @@ module.exports = (env, argv) => {
                                     // up with broken CSS.
                                     require('postcss-preset-env')({stage: 3, browsers: 'last 2 versions'}),
                                 ],
-                                "parser": "postcss-scss",
+                                parser: "postcss-scss",
                                 "local-plugins": true,
                             },
                         },
@@ -233,8 +233,8 @@ module.exports = (env, argv) => {
                             loader: 'postcss-loader',
                             ident: 'postcss',
                             options: {
-                                "sourceMap": true,
-                                "plugins": () => [
+                                sourceMap: true,
+                                plugins: () => [
                                     // Note that we use slightly different plugins for SCSS.
 
                                     require('postcss-import')(),
@@ -251,7 +251,7 @@ module.exports = (env, argv) => {
                                     // up with broken CSS.
                                     require('postcss-preset-env')({stage: 3, browsers: 'last 2 versions'}),
                                 ],
-                                "parser": "postcss-scss",
+                                parser: "postcss-scss",
                                 "local-plugins": true,
                             },
                         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,8 @@ const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const webpack = require("webpack");
 
-let og_image_url = process.env.RIOT_OG_IMAGE_URL;
-if (!og_image_url) og_image_url = 'https://app.element.io/themes/element/img/logos/opengraph.png';
+let ogImageUrl = process.env.RIOT_OG_IMAGE_URL;
+if (!ogImageUrl) ogImageUrl = 'https://app.element.io/themes/element/img/logos/opengraph.png';
 
 const additionalPlugins = [
     // This is where you can put your customisation replacements.
@@ -124,11 +124,11 @@ module.exports = (env, argv) => {
                 // overflows (https://github.com/webpack/webpack/issues/1721), and
                 // there is no need for webpack to parse them - they can just be
                 // included as-is.
-                /highlight\.js[\\\/]lib[\\\/]languages/,
+                /highlight\.js[\\/]lib[\\/]languages/,
 
                 // olm takes ages for webpack to process, and it's already heavily
                 // optimised, so there is little to gain by us uglifying it.
-                /olm[\\\/](javascript[\\\/])?olm\.js$/,
+                /olm[\\/](javascript[\\/])?olm\.js$/,
             ],
             rules: [
                 {
@@ -152,8 +152,8 @@ module.exports = (env, argv) => {
                     },
                     loader: 'babel-loader',
                     options: {
-                        cacheDirectory: true
-                    }
+                        cacheDirectory: true,
+                    },
                 },
                 {
                     test: /\.css$/,
@@ -164,14 +164,14 @@ module.exports = (env, argv) => {
                             options: {
                                 importLoaders: 1,
                                 sourceMap: true,
-                            }
+                            },
                         },
                         {
                             loader: 'postcss-loader',
                             ident: 'postcss',
                             options: {
-                                sourceMap: true,
-                                plugins: () => [
+                                "sourceMap": true,
+                                "plugins": () => [
                                     // Note that we use significantly fewer plugins on the plain
                                     // CSS parser. If we start to parse plain CSS, we end with all
                                     // kinds of nasty problems (like stylesheets not loading).
@@ -198,11 +198,11 @@ module.exports = (env, argv) => {
                                     // up with broken CSS.
                                     require('postcss-preset-env')({stage: 3, browsers: 'last 2 versions'}),
                                 ],
-                                parser: "postcss-scss",
+                                "parser": "postcss-scss",
                                 "local-plugins": true,
                             },
                         },
-                    ]
+                    ],
                 },
                 {
                     test: /\.scss$/,
@@ -213,14 +213,14 @@ module.exports = (env, argv) => {
                             options: {
                                 importLoaders: 1,
                                 sourceMap: true,
-                            }
+                            },
                         },
                         {
                             loader: 'postcss-loader',
                             ident: 'postcss',
                             options: {
-                                sourceMap: true,
-                                plugins: () => [
+                                "sourceMap": true,
+                                "plugins": () => [
                                     // Note that we use slightly different plugins for SCSS.
 
                                     require('postcss-import')(),
@@ -237,11 +237,11 @@ module.exports = (env, argv) => {
                                     // up with broken CSS.
                                     require('postcss-preset-env')({stage: 3, browsers: 'last 2 versions'}),
                                 ],
-                                parser: "postcss-scss",
+                                "parser": "postcss-scss",
                                 "local-plugins": true,
                             },
                         },
-                    ]
+                    ],
                 },
                 {
                     test: /\.wasm$/,
@@ -311,7 +311,7 @@ module.exports = (env, argv) => {
                         },
                     ],
                 },
-            ]
+            ],
         },
 
         plugins: [
@@ -332,7 +332,7 @@ module.exports = (env, argv) => {
                 excludeChunks: ['mobileguide', 'usercontent', 'jitsi'],
                 minify: argv.mode === 'production',
                 vars: {
-                    og_image_url: og_image_url,
+                    og_image_url: ogImageUrl,
                 },
             }),
 
@@ -438,6 +438,7 @@ function getAssetOutputPath(url, resourcePath) {
  * be placed directly into things like CSS files.
  *
  * @param {string} path Some path to a file.
+ * @returns {string} converted path
  */
 function toPublicPath(path) {
     return path.replace(/\\/g, '/');


### PR DESCRIPTION
Improves vector-im/element-web#14750

More and more people use Nightly builds as their main client. When bundling the app in a CI environment webpack is in development mode.

Doing so means that sources are not minified, we benefit from source maps, BUT we run React development build. Which is great when an engineer is actively working on the app, but adds significant runtime overhead (3-5x slower in development compared to production)

![Screen Shot 2021-04-15 at 12 49 46](https://user-images.githubusercontent.com/769871/114885169-51872f00-9dfe-11eb-8cb1-f73f79254d07.png)

* Fig1: React production, room filtering in a "small" account, 65ms blocking time, 445ms script execution time
* Fig2: React development, room filtering in a "small" account, 401.6ms blocking time, 1461 script execution time

PS: Sorry for the larger diff, the linter was not happy, the tl;dr is [`0532c9c`](https://github.com/vector-im/element-web/commit/0532c9c37bf5e881671275f194df0b8faadf1ec1)
