### PR TITLE
Disable `postcss-calc`'s noisy `warnWhenCannotResolve` option

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -243,7 +243,7 @@ module.exports = (env, argv) => {
                                     require("postcss-easings")(),
                                     require("postcss-strip-inline-comments")(),
                                     require("postcss-hexrgba")(),
-                                    require("postcss-calc")({warnWhenCannotResolve: true}),
+                                    require("postcss-calc")(),
 
                                     // It's important that this plugin is last otherwise we end
                                     // up with broken CSS.


### PR DESCRIPTION
While it sounds like a useful warning at first, it turns out the warnings it prints are ones we're unlike to ever act on, such as adding percentages and pixels, which seem fine to have. This resets to default behaviour, which leaves the warning off.