### PR TITLE
Update jsrsasign to ^10.2.0 (Includes fix for CVE-2021-30246)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "browser-request": "^0.3.3",
     "gfm.css": "^1.1.2",
     "highlight.js": "^10.5.0",
-    "jsrsasign": "^10.1.5",
+    "jsrsasign": "^10.2.0",
     "katex": "^0.12.0",
     "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
     "matrix-react-sdk": "github:matrix-org/matrix-react-sdk#develop",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7304,10 +7304,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsrsasign@^10.1.5:
-  version "10.1.5"
-  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.1.5.tgz#d59127cf76f5d12211a7849fafdb7e0cddab6139"
-  integrity sha512-xlCtvZ+S2fPnw6YQyPkgMZ1dgMJ02bmK5Rt1umpo/KThBP6Zzq9awzXU71NEw1NYxXmLFnjorpQYKLZzMdF3lg==
+jsrsasign@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.2.0.tgz#960ab8046d19d3fcbb584368a57d1977cb0b7ffd"
+  integrity sha512-khMrV/10U02DRzmXhjuLQjddUF39GHndaJZ/3YiiKkbyEl1T5M6EQF9nQUq0DFVCHusmd/jl8TWl4mWt+1L5hg==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.2.0"


### PR DESCRIPTION
See https://github.com/kjur/jsrsasign/security/advisories/GHSA-27fj-mc8w-j9wg
for details.

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off at the end of your Pull Request (as described in CONTRIBUTING.md), or on every commit -->
