### PR TITLE
Disable host checking on the webpack dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dist": "scripts/package.sh",
     "start": "concurrently --kill-others-on-fail --prefix \"{time} [{name}]\" -n reskindex,reskindex-react,res,element-js \"yarn reskindex:watch\" \"yarn reskindex:watch-react\" \"yarn start:res\" \"yarn start:js\"",
     "start:res": "yarn build:jitsi && node scripts/copy-res.js -w",
-    "start:js": "webpack-dev-server --host=0.0.0.0 --output-filename=bundles/_dev_/[name].js --output-chunk-filename=bundles/_dev_/[name].js -w --progress --mode development",
+    "start:js": "webpack-dev-server --host=0.0.0.0 --output-filename=bundles/_dev_/[name].js --output-chunk-filename=bundles/_dev_/[name].js -w --progress --mode development --disable-host-check",
     "lint": "yarn lint:types && yarn lint:js && yarn lint:style",
     "lint:js": "eslint src",
     "lint:types": "tsc --noEmit --jsx react",


### PR DESCRIPTION
This is useful when you're doing cross-browser testing on a service which demands you use "localhost.com" for reasons.

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off at the end of your Pull Request (as described in CONTRIBUTING.md), or on every commit -->
