### PR TITLE
Prevent minification of `.html` files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -386,7 +386,7 @@ module.exports = (env, argv) => {
                 // of the themes and which chunks we actually care about.
                 inject: false,
                 excludeChunks: ['mobileguide', 'usercontent', 'jitsi'],
-                minify: argv.mode === 'production',
+                minify: false,
                 templateParameters: {
                     og_image_url: ogImageUrl,
                 },
@@ -396,7 +396,7 @@ module.exports = (env, argv) => {
             new HtmlWebpackPlugin({
                 template: './src/vector/jitsi/index.html',
                 filename: 'jitsi.html',
-                minify: argv.mode === 'production',
+                minify: false,
                 chunks: ['jitsi'],
             }),
 
@@ -404,7 +404,7 @@ module.exports = (env, argv) => {
             new HtmlWebpackPlugin({
                 template: './src/vector/mobile_guide/index.html',
                 filename: 'mobile_guide/index.html',
-                minify: argv.mode === 'production',
+                minify: false,
                 chunks: ['mobileguide'],
             }),
 
@@ -412,13 +412,13 @@ module.exports = (env, argv) => {
             new HtmlWebpackPlugin({
                 template: './src/vector/static/unable-to-load.html',
                 filename: 'static/unable-to-load.html',
-                minify: argv.mode === 'production',
+                minify: false,
                 chunks: [],
             }),
             new HtmlWebpackPlugin({
                 template: './src/vector/static/incompatible-browser.html',
                 filename: 'static/incompatible-browser.html',
-                minify: argv.mode === 'production',
+                minify: false,
                 chunks: [],
             }),
 
@@ -426,7 +426,7 @@ module.exports = (env, argv) => {
             new HtmlWebpackPlugin({
                 template: './node_modules/matrix-react-sdk/src/usercontent/index.html',
                 filename: 'usercontent/index.html',
-                minify: argv.mode === 'production',
+                minify: false,
                 chunks: ['usercontent'],
             }),
 


### PR DESCRIPTION
As described in https://github.com/vector-im/element-web/issues/17330#issuecomment-842530812, this should prevent the newly introduced version of `html-webpack-plugin` from minifying `.html` files, like e.g. `index.html`, `jitsi.html`, et cetera …

Quoting @jryans via https://github.com/vector-im/element-web/issues/17330#issuecomment-842415694:

> The content of the `index.html` file is not a supported API surface, so it might change at any time.
> 
> This document minification was not done on purpose, but instead it happened as a side effect of upgrading. We would happily accept a PR to fix this, but it is also not a priority for the core team.

Could someone with a dev environment please test and, hopefully, accept this change back to not minifying the `.html` files?

Thank you very much.

—
Signed-off-by: [fooness](mailto:fooness@users.noreply.github.com)
