### PR TITLE
Remove logo spinner

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -25,9 +25,7 @@
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
     "defaultCountryCode": "GB",
     "showLabsSettings": false,
-    "features": {
-        "feature_new_spinner": false
-    },
+    "features": { },
     "default_federate": true,
     "default_theme": "light",
     "roomDirectory": {

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -62,9 +62,7 @@ Then you can deploy it to your cluster with something like `kubectl apply -f my-
             "bug_report_endpoint_url": "https://element.io/bugreports/submit",
             "defaultCountryCode": "GB",
             "showLabsSettings": false,
-            "features": {
-                "feature_new_spinner": false
-            },
+            "features": { },
             "default_federate": true,
             "default_theme": "light",
             "roomDirectory": {

--- a/docs/labs.md
+++ b/docs/labs.md
@@ -19,10 +19,6 @@ Still in heavy development.
 
 Enables rendering of LaTeX maths in messages using [KaTeX](https://katex.org/). LaTeX between single dollar-signs is interpreted as inline maths and double dollar-signs as display maths (i.e. centred on its own line).
 
-## New spinner design (`feature_new_spinner`)
-
-Replaces the old spinner image with a new, svg-based one featuring a sleeker design.
-
 ## Message pinning (`feature_pinning`)
 
 Allows you to pin messages in the room. To pin a message, use the 3 dots to the right of the message


### PR DESCRIPTION
Removed since design wants to avoid associating slowness with the brand (goes with matrix-org/matrix-react-sdk#6078).