### PR TITLE
Fix Olm asm.js support

### DIFF
--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -69,7 +69,7 @@ const COPY_LIST = [
     ["res/vector-icons/**", "webapp/vector-icons"],
     ["res/decoder-ring/**", "webapp/decoder-ring"],
     ["node_modules/matrix-react-sdk/res/media/**", "webapp/media"],
-    ["node_modules/olm/olm_legacy.js", "webapp", { directwatch: 1 }],
+    ["node_modules/@matrix-org/olm/olm_legacy.js", "webapp", { directwatch: 1 }],
     ["./config.json", "webapp", { directwatch: 1 }],
     ["contribute.json", "webapp"],
 ];


### PR DESCRIPTION
The package name was updated in #17433, but this path to copy `olm_legacy.js` into place was overlooked.

Closes #17463.