### PR TITLE
Preload only `woff2` fonts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -431,7 +431,7 @@ module.exports = (env, argv) => {
             }),
 
             new HtmlWebpackInjectPreload({
-                files: [{ match: /.*Inter.*\.woff2?$/ }],
+                files: [{ match: /.*Inter.*\.woff2$/ }],
             }),
 
             ...additionalPlugins,


### PR DESCRIPTION
All of our supported browsers understand `woff2`, so there's no need to make everyone preload the older `woff` as well.