### PR TITLE
Remove spurious overflow: auto on #matrixchat element

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -65,7 +65,7 @@
       data-vector-recorder-worklet-script="<%= htmlWebpackPlugin.files.js.find(entry => entry.includes("recorder-worklet.js")) %>"
   >
     <noscript>Sorry, Element requires JavaScript to be enabled.</noscript> <!-- TODO: Translate this? -->
-    <section id="matrixchat" style="height: 100%; overflow: auto;" class="notranslate"></section>
+    <section id="matrixchat" style="height: 100%;" class="notranslate"></section>
     <script src="<%= htmlWebpackPlugin.files.js.find(entry => entry.includes("bundle.js")) %>"></script>
 
     <!-- Legacy supporting Prefetch images -->


### PR DESCRIPTION
Fixes the following warning for https://github.com/matrix-org/matrix-react-sdk/pull/6137
![image](https://user-images.githubusercontent.com/2403652/122010331-eed8f200-cdb2-11eb-8f00-67d9bda8cbbd.png)
