### PR TITLE
Add libera.chat to default room directory

### DIFF
--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -21,7 +21,8 @@
     "roomDirectory": {
         "servers": [
             "matrix.org",
-            "gitter.im"
+            "gitter.im",
+            "libera.chat"
         ]
     },
     "enable_presence_by_hs_url": {

--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -21,7 +21,8 @@
     "roomDirectory": {
         "servers": [
             "matrix.org",
-            "gitter.im"
+            "gitter.im",
+            "libera.chat"
         ]
     },
     "enable_presence_by_hs_url": {


### PR DESCRIPTION
I've seen a fair number of people asking how to get to these rooms. It seems like it would make sense to add this to the default room directory.