### PR TITLE
Fix canvas-filter-polyfill mock path

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
       "decoderWorker\\.min\\.js": "<rootDir>/node_modules/matrix-react-sdk/__mocks__/empty.js",
       "decoderWorker\\.min\\.wasm": "<rootDir>/node_modules/matrix-react-sdk/__mocks__/empty.js",
       "waveWorker\\.min\\.js": "<rootDir>/node_modules/matrix-react-sdk/__mocks__/empty.js",
-      "context-filter-polyfill": "<rootDir>/__mocks__/empty.js"
+      "context-filter-polyfill": "<rootDir>/node_modules/matrix-react-sdk/__mocks__/empty.js"
     },
     "transformIgnorePatterns": [
       "/node_modules/(?!matrix-js-sdk).+$",


### PR DESCRIPTION
Following #17774, fixing a bad copy paste for the path