### PR TITLE
Enhance security by disallowing CSP object-src rule

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -35,7 +35,6 @@
         worker-src 'self';
         frame-src * blob: data:;
         form-action 'self';
-        object-src 'self';
         manifest-src 'self';
     ">
     <% for (var i=0; i < htmlWebpackPlugin.files.css.length; i++) {


### PR DESCRIPTION
Fixes vector-im/element-web#6162

Requires matrix-org/matrix-react-sdk#6279