### PR TITLE
Remove canvas native dependencies from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,7 @@ ARG REACT_SDK_BRANCH="master"
 ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
 ARG JS_SDK_BRANCH="master"
 
-RUN apt-get update && apt-get install -y git dos2unix \
-# These packages are required for building Canvas on architectures like Arm
-# See https://www.npmjs.com/package/canvas#compiling
-  build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+RUN apt-get update && apt-get install -y git dos2unix
 
 WORKDIR /src
 


### PR DESCRIPTION
As of https://github.com/vector-im/element-web/pull/17967, `canvas` is no longer used, so we don't need install these native deps for building it on arm64.