### PR TITLE
Add setup instructions for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,21 @@ If any of these steps error with, `file table overflow`, you are probably on a m
 which has a very low limit on max open files. Run `ulimit -Sn 1024` and try again.
 You'll need to do this in each new terminal you open before building Element.
 
+Apple Silicon on OS X
+---------------------
+
+For now, the `node-canvas` dependency requires some binary dependencies to be pre-installed on ARM64 Apple Silicon, e.g. M1 processors.
+
+Homebrew users can run
+
+`arch -arm64 brew install pkg-config cairo pango libpng jpeg giflib librsvg`
+
+And pass `CPLUS_INCLUDE_PATH` to `yarn` during the `install` step:
+
+`CPLUS_INCLUDE_PATH=/opt/homebrew/include yarn install`
+
+See https://github.com/Automattic/node-canvas/issues/1733
+
 Running the tests
 -----------------
 


### PR DESCRIPTION
Added some instructions based on my personal experience setting up a dev environment on an M1 mac. node-canvas is built from source on ARM64 and needs some binary dependencies.

I think this will become unnecessary once https://github.com/Automattic/node-canvas/issues/1662 is addressed.