### PR TITLE
Add VS Code to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ electron/pub
 /src/component-index.js
 /.tmp
 /webpack-stats.json
+.vscode
+.vscode/


### PR DESCRIPTION
We ignore both the directory and file since a symlink acts as a file and you might want to symlink a global config directory for all Element related projects