### PR TITLE
Fix browser history getting stuck looping back to the same room

### DIFF
--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -74,7 +74,10 @@ function onNewScreen(screen: string, replaceLast = false) {
     lastLocationHashSet = hash;
 
     // if the new hash is a substring of the old one then we are stripping fields e.g `via` so replace history
-    if (screen.startsWith("room/") && window.location.hash.startsWith(hash)) {
+    if (screen.startsWith("room/") &&
+        window.location.hash.includes("/$") === hash.includes("/$") && // only if both did or didn't contain event link
+        window.location.hash.startsWith(hash)
+    ) {
         replaceLast = true;
     }
 

--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -73,6 +73,11 @@ function onNewScreen(screen: string, replaceLast = false) {
     const hash = '#/' + screen;
     lastLocationHashSet = hash;
 
+    // if the new hash is a substring of the old one then we are stripping fields e.g `via` so replace history
+    if (screen.startsWith("room/") && window.location.hash.startsWith(hash)) {
+        replaceLast = true;
+    }
+
     if (replaceLast) {
         window.location.replace(hash);
     } else {


### PR DESCRIPTION
E.g if you click a link to room/#foo:bar?via=baz we'll redirect to room/#foo:bar and now hitting back takes you back to the ?via=baz and means you have to hit back twice without this change
