### PR TITLE
Add the Matrix Space to the translations guide

### DIFF
--- a/docs/translating.md
+++ b/docs/translating.md
@@ -8,8 +8,9 @@
 
 ## Step 0: Join #element-translations:matrix.org
 
-1. Come and join https://matrix.to/#/#element-translations:matrix.org
-2. Read scrollback and/or ask if anyone else is working on your language, and co-ordinate if needed.  In general little-or-no coordination is needed though :)
+1. Come and join https://matrix.to/#/#element-translations:matrix.org for general discussion 
+2. Join https://matrix.to/#/#element-translators:matrix.org for language-specific rooms
+3. Read scrollback and/or ask if anyone else is working on your language, and co-ordinate if needed.  In general little-or-no coordination is needed though :)
 
 ## Step 1: Preparing your Weblate Profile
 


### PR DESCRIPTION
This adds the new [translators space](https://matrix.to/#/#element-translators:matrix.org) to the translations guide.