### PR TITLE
Include posthog sentry types override

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,12 @@
       "es2019",
       "dom",
       "dom.iterable"
-    ]
+    ],
+    "paths": {
+      "posthog-js": [
+        "../matrix-react-sdk/src/@types/posthog.d.ts"
+      ]
+    }
   },
   "include": [
     "./src/**/*.ts",


### PR DESCRIPTION
Duplicating this config from matrix-react-sdk is necessary because the element-web lint process is also type checking matrix-react-sdk.

This will fix lint type errors about sentry, although locally at least I can see there are some other errors around React type duplication that also need to be fixed.

