### PR TITLE
Triage automation: update token

### DIFF
--- a/.github/workflows/triage-incoming.yml
+++ b/.github/workflows/triage-incoming.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           project: Issue triage
           column: Incoming
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ELEMENT_BOT_TOKEN }}


### PR DESCRIPTION
GitHub bug means that GITHUB_TOKEN doesn't work according to
documentation at https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token because it doesn't have the right permissions for moving stuff to a project board.

The automation throws this error:
Error: Resource not accessible by integration

Use our own generated token for now.

Signed-off-by: Ekaterina Gerasimova <kittykat3756@gmail.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->
