### PR TITLE
Issue triage: move priority bugs onto team board

### DIFF
--- a/.github/workflows/triage-priority-bugs.yml
+++ b/.github/workflows/triage-priority-bugs.yml
@@ -1,0 +1,20 @@
+name: Move labelled issues into the Priority bugs column for the Web App Team
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  Move_high_priority_issues_to_team_workboard:
+    runs-on: ubuntu-latest
+    if: >
+        contains(github.event.issue.labels.*.name, 'S-Critical') && (contains(github.event.issue.labels.*.name, 'P-High') ||  contains(github.event.issue.labels.*.name, 'P-Medium')) ||
+        contains(github.event.issue.labels.*.name, 'S-Major') && contains(github.event.issue.labels.*.name, 'P-High') ||
+        contains(github.event.issue.labels.*.name, 'A11y') && contains(github.event.issue.labels.*.name, 'P-High')
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Web App Team
+          column: Priority bugs
+          repo-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
+


### PR DESCRIPTION
Automatically move all bugs with the right label combinations onto the Priority bugs column on the Web App Team's board.

Signed-off-by: Ekaterina Gerasimova <kittykat3756@gmail.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->