### PR TITLE
Issue triage: move only defects into priority bugs

### DIFF
--- a/.github/workflows/triage-priority-bugs.yml
+++ b/.github/workflows/triage-priority-bugs.yml
@@ -8,6 +8,7 @@ jobs:
   Move_high_priority_issues_to_team_workboard:
     runs-on: ubuntu-latest
     if: >
+        contains(github.event.issue.labels.*.name, 'T-Defect') &&
         contains(github.event.issue.labels.*.name, 'S-Critical') &&
         (contains(github.event.issue.labels.*.name, 'O-Frequent') ||
          contains(github.event.issue.labels.*.name, 'O-Intermediate')) ||


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->