### PR TITLE
Fix isues with CSS hot-reload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ CSS_HOT_RELOAD=1
 # To use a single theme, uncomment the line with the theme you want to hot-reload.
 MATRIX_THEMES='light'
 #MATRIX_THEMES='dark'
-#MATRIX_THEMES='light-legacy'
-#MATRIX_THEMES='dark-legacy'
+#MATRIX_THEMES='legacy-light'
+#MATRIX_THEMES='legacy-dark'
 #MATRIX_THEMES='light-custom'
 #MATRIX_THEMES='dark-custom'
 # You can also enable multiple themes by using a comma-separated list.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ if (!ogImageUrl) ogImageUrl = 'https://app.element.io/themes/element/img/logos/o
 
 const cssThemes = {
     // CSS themes
-    "theme-legacy": "./node_modules/matrix-react-sdk/res/themes/legacy-light/css/legacy-light.scss",
+    "theme-legacy-light": "./node_modules/matrix-react-sdk/res/themes/legacy-light/css/legacy-light.scss",
     "theme-legacy-dark": "./node_modules/matrix-react-sdk/res/themes/legacy-dark/css/legacy-dark.scss",
     "theme-light": "./node_modules/matrix-react-sdk/res/themes/light/css/light.scss",
     "theme-dark": "./node_modules/matrix-react-sdk/res/themes/dark/css/dark.scss",


### PR DESCRIPTION
This PR fixes two issues with CSS hot-reload when using legacy themes:

1. The name of the legacy themes in `.env.sample` is wrong. The themes are called `legacy-light` and `legacy-dark` and not `light-legacy` and `dark-legacy`, respectively.
2. When the `legacy-light` theme is enabled in `.env`, e.g. `MATRIX_THEMES='legacy-light'`, running `yarn start` results in the following error:

```
const themeImportPath = cssThemes[`theme-${ t }`].replace('./node_modules/', '');
                                                  ^
TypeError: Cannot read property 'replace' of undefined
    at element-web/webpack.config.js:70:63
    at Array.map (<anonymous>)
    at getThemesImports (element-web/webpack.config.js:69:39)
```

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->