### PR TITLE
Document missing features in labs.md

### DIFF
--- a/docs/labs.md
+++ b/docs/labs.md
@@ -133,3 +133,7 @@ and notification noises are suppressed. Not perfect, but can help reduce noise.
 ## Hidden read receipts (`feature_hidden_read_receipts`)
 
 Enables sending hidden read receipts as per [MSC2285](https://github.com/matrix-org/matrix-doc/pull/2285)
+
+## New layout switcher (with message bubbles) (`feature_new_layout_switcher`)
+
+Adds a "Message layout" section under `Settings -> Appearance`, where the user can select their preferred message layout (e.g. IRC or Modern). Additionally, adds a new "Message bubbles" layout.


### PR DESCRIPTION
Document `feature_new_layout_switcher` flag to `labs.md`.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->