### PR TITLE
Issue templates: merge expected and actual results

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-desktop.yml
+++ b/.github/ISSUE_TEMPLATE/bug-desktop.yml
@@ -21,17 +21,14 @@ body:
     validations:
       required: true
   - type: textarea
-    id: what-happened
+    id: result
     attributes:
       label: What happened?
       placeholder: Tell us what went wrong
-    validations:
-      required: true
-  - type: textarea
-    id: expected-result
-    attributes:
-      label: What did you expect?
-      placeholder: Tell us what you expected to happen
+      value: |
+        ### What did you expect?
+
+        ### What happened?
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug-web.yml
+++ b/.github/ISSUE_TEMPLATE/bug-web.yml
@@ -21,17 +21,14 @@ body:
     validations:
       required: true
   - type: textarea
-    id: what-happened
+    id: result
     attributes:
       label: What happened?
       placeholder: Tell us what went wrong
-    validations:
-      required: true
-  - type: textarea
-    id: expected-result
-    attributes:
-      label: What did you expect?
-      placeholder: Tell us what you expected to happen
+      value: |
+        ### What did you expect?
+
+        ### What happened?
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Feedback received asking to merge templates so they take up less space
and are quicker for developers to fill.

The new template will look like this:
![Screenshot from 2021-09-03 10-30-16](https://user-images.githubusercontent.com/51663/131983941-2f9c026b-48a6-4353-91e8-5c61d95b028d.png)

Instead of this:
![Screenshot from 2021-09-03 10-32-43](https://user-images.githubusercontent.com/51663/131984094-d942bac9-0e96-4a5c-9833-8c0552ef3390.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->