### PR TITLE
Revert "Issue automation: test GitHub's new shiny boards"

### DIFF
--- a/.github/workflows/issues_to_projects.yaml
+++ b/.github/workflows/issues_to_projects.yaml
@@ -19,20 +19,3 @@ jobs:
                  project-url: "https://github.com/orgs/vector-im/projects/14"
                  column-name: "📥 Inbox"
                  label-name: "X-Needs-Design"
-    test_board_beta_with_design_issues:
-        name: Move priority X-Needs-Design issues to Beta test project board
-        runs-on: ubuntu-latest
-        if: >
-            contains(github.event.issue.labels.*.name, 'X-Needs-Design') &&
-             (contains(github.event.issue.labels.*.name, 'O-Frequent') ||
-              contains(github.event.issue.labels.*.name, 'O-Intermediate')) &&
-             (contains(github.event.issue.labels.*.name, 'S-Critical') ||
-              contains(github.event.issue.labels.*.name, 'S-Major') ||
-              contains(github.event.issue.labels.*.name, 'S-Minor'))
-        steps:
-             - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
-               with:
-                 action-token: "${{ secrets.ELEMENT_BOT_TOKEN }}"
-                 project-url: "https://github.com/orgs/vector-im/projects/15"
-                 column-name: "Todo"
-                 label-name: "X-Needs-Design"


### PR DESCRIPTION
Beta boards automation is different from old boards

This reverts commit b873185c684843484ada463eb7c06bdc42036dde.

Signed-off-by: Ekaterina Gerasimova <ekaterinag@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->