### PR TITLE
Enable posthog on develop

### DIFF
--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -52,5 +52,9 @@
     "sentry": {
         "dsn": "https://029a0eb289f942508ae0fb17935bd8c5@sentry.matrix.org/6",
         "environment": "develop"
+    },
+    "posthog": {
+        "projectApiKey": "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO",
+        "apiHost": "https://posthog.hss.element.io"
     }
 }


### PR DESCRIPTION
Point posthog nightly at prod posthog infrastructure. This will enable posthog tracking for those who have switched labs flag on, on develop.

See https://github.com/vector-im/element-web/blob/develop/docs/config.md

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->