### PR TITLE
Fix link to README in translation-docs again

### DIFF
--- a/docs/translating-dev.md
+++ b/docs/translating-dev.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- A working [Development Setup](../#setting-up-a-dev-environment)
+- A working [Development Setup](../README.md#setting-up-a-dev-environment)
   - Including up-to-date versions of matrix-react-sdk and matrix-js-sdk
 - Latest LTS version of Node.js installed
 - Be able to understand English


### PR DESCRIPTION
Fixing it once more because https://github.com/vector-im/element-web/pull/19080 didn't work out as intended.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->