### PR TITLE
Removed iOS app Jitsi homeserver URL notice in the documentation

### DIFF
--- a/docs/jitsi.md
+++ b/docs/jitsi.md
@@ -64,10 +64,3 @@ The domain used is the one specified by the `/.well-known/matrix/client` endpoin
 For active Jitsi widgets in the room, a native Jitsi widget UI is created and points to the instance specified in the `domain` key of the widget content data.
 
 Element Android manages allowed native widgets permissions a bit differently than web widgets (as the data shared are different and never shared with the widget URL). For Jitsi widgets, permissions are requested only once per domain (consent saved in account data).
-
-## Element iOS
-
-Currently the Element mobile apps do not support custom Jitsi servers and will instead
-use the default `jitsi.riot.im` server. When users on the mobile apps join the call,
-they will be joining a different conference which has the same name, but not the same
-participants. This is a known bug and which needs to be fixed.


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

I've removed the (old) documentation notice about the iOS Element client that ignored the homeserver configuration for a custom Jitsi URL.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Related issues/pull requests:
* https://github.com/vector-im/element-ios/issues/3158
* https://github.com/vector-im/element-ios/pull/4283

<!-- To specify text for the changelog entry (otherwise the PR title will be used):


Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none

-->

Notes: Removed iOS app Jitsi homeserver URL notice in the documentation

Signed-off-by: Max Kratz <account@maxkratz.com>


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->