### PR TITLE
Don't give E2EE and spaces issues to web app team

### DIFF
--- a/.github/workflows/triage-priority-bugs.yml
+++ b/.github/workflows/triage-priority-bugs.yml
@@ -2,20 +2,28 @@ name: Move labelled issues into the Priority bugs column for the Web App Team
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, unlabeled]
 
 jobs:
   Move_high_priority_issues_to_team_workboard:
     runs-on: ubuntu-latest
     if: >
-        contains(github.event.issue.labels.*.name, 'T-Defect') &&
-        contains(github.event.issue.labels.*.name, 'S-Critical') &&
-        (contains(github.event.issue.labels.*.name, 'O-Frequent') ||
-         contains(github.event.issue.labels.*.name, 'O-Occasional')) ||
-        contains(github.event.issue.labels.*.name, 'S-Major') &&
-        contains(github.event.issue.labels.*.name, 'O-Frequent') ||
-        contains(github.event.issue.labels.*.name, 'A11y') &&
-        contains(github.event.issue.labels.*.name, 'O-Frequent')
+        (!contains(github.event.issue.labels.*.name, 'A-E2EE') &&
+         !contains(github.event.issue.labels.*.name, 'A-E2EE-Cross-Signing') &&
+         !contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') &&
+         !contains(github.event.issue.labels.*.name, 'A-E2EE-Key-Backup') &&
+         !contains(github.event.issue.labels.*.name, 'A-E2EE-SAS-Verification') &&
+         !contains(github.event.issue.labels.*.name, 'A-Spaces') &&
+         !contains(github.event.issue.labels.*.name, 'A-Spaces-Settings') &&
+         !contains(github.event.issue.labels.*.name, 'A-Subspaces')) &&
+        (contains(github.event.issue.labels.*.name, 'T-Defect') &&
+         contains(github.event.issue.labels.*.name, 'S-Critical') &&
+         (contains(github.event.issue.labels.*.name, 'O-Frequent') ||
+          contains(github.event.issue.labels.*.name, 'O-Occasional')) ||
+         contains(github.event.issue.labels.*.name, 'S-Major') &&
+         contains(github.event.issue.labels.*.name, 'O-Frequent') ||
+         contains(github.event.issue.labels.*.name, 'A11y') &&
+         contains(github.event.issue.labels.*.name, 'O-Frequent'))
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:


### PR DESCRIPTION
All incoming issues labelled with A-E2EE* and A-*spaces* labels should go to appropriate teams, and not to P1 in the web app team project.

Review of logic would be appreciated.

Signed-off-by: Ekaterina Gerasimova <ekaterinag@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->