### PR TITLE
Update minification and sourcemap settings on CI builds for sentry

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,10 +42,6 @@ function getActiveThemes() {
 module.exports = (env, argv) => {
     let nodeEnv;
     if (process.env.CI_PACKAGE) {
-        // Don't run minification for CI builds (this is only set for runs on develop)
-        // We override this via environment variable to avoid duplicating the scripts
-        // in `package.json` just for a different mode.
-        argv.mode = "development";
         // More and more people are using nightly build as their main client
         // Libraries like React have a development build that is useful
         // when working on the app but adds significant runtime overhead
@@ -58,8 +54,8 @@ module.exports = (env, argv) => {
     const devMode = nodeEnv !== 'production';
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;
     const fullPageErrors = process.env.FULL_PAGE_ERRORS === '1' && devMode;
-    const enableMinification = argv.mode === "production";
-    const enableSourceMaps = argv.mode === "production";
+    const enableMinification = argv.mode === "production" && !process.env.CI_PACKAGE;
+    const enableSourceMaps = argv.mode === "production" && !process.env.CI_PACKAGE;
 
     const development = {};
     if (enableSourceMaps) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ function getActiveThemes() {
 }
 
 module.exports = (env, argv) => {
-    let nodeEnv = argv.mode;
+    let nodeEnv;
     if (process.env.CI_PACKAGE) {
         // Don't run minification for CI builds (this is only set for runs on develop)
         // We override this via environment variable to avoid duplicating the scripts
@@ -52,6 +52,8 @@ module.exports = (env, argv) => {
         // We want to use the React production build but not compile the whole
         // application to productions standards
         nodeEnv = "production";
+    } else {
+        nodeEnv = argv.mode;
     }
     const devMode = nodeEnv !== 'production';
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = (env, argv) => {
     const devMode = nodeEnv !== 'production';
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;
     const fullPageErrors = process.env.FULL_PAGE_ERRORS === '1' && devMode;
-    const enableMinification = argv.mode === "production" && !process.env.CI_PACKAGE;
+    const enableMinification = argv.mode === "production";
     const disableSourceMaps = argv.mode === "production" && !process.env.CI_PACKAGE;
 
     const development = {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,10 +55,10 @@ module.exports = (env, argv) => {
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;
     const fullPageErrors = process.env.FULL_PAGE_ERRORS === '1' && devMode;
     const enableMinification = argv.mode === "production" && !process.env.CI_PACKAGE;
-    const enableSourceMaps = argv.mode === "production" && !process.env.CI_PACKAGE;
+    const disableSourceMaps = argv.mode === "production" && !process.env.CI_PACKAGE;
 
     const development = {};
-    if (enableSourceMaps) {
+    if (disableSourceMaps) {
         development['devtool'] = 'nosources-source-map';
     } else {
         // This makes the sourcemaps human readable for developers. We use eval-source-map

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,15 +53,21 @@ module.exports = (env, argv) => {
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;
     const fullPageErrors = process.env.FULL_PAGE_ERRORS === '1' && devMode;
     const enableMinification = argv.mode === "production";
-    const disableSourceMaps = argv.mode === "production" && !process.env.CI_PACKAGE;
 
     const development = {};
-    if (disableSourceMaps) {
-        development['devtool'] = 'nosources-source-map';
+    if (devMode) {
+        // High quality, embedded source maps for dev builds
+        development['devtool'] = "eval-source-map";
     } else {
-        // This makes the sourcemaps human readable for developers. We use eval-source-map
-        // because the plain source-map devtool ruins the alignment.
-        development['devtool'] = 'eval-source-map';
+        if (process.env.CI_PACKAGE) {
+            // High quality source maps in separate .map files which include the source. This doesn't bulk up the .js
+            // payload file size, which is nice for performance but also necessary to get the bundle to a small enough
+            // size that sentry will accept the upload.
+            development['devtool'] = 'source-map';
+        } else {
+            // High quality source maps in separate .map files which don't include the source
+            development['devtool'] = 'nosources-source-map';
+        }
     }
 
     // Resolve the directories for the react-sdk and js-sdk for later use. We resolve these early so we

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,14 @@ function getActiveThemes() {
 }
 
 module.exports = (env, argv) => {
+    // Establish settings based on the environment and args.
+    //
+    // argv.mode is always set to "production" by yarn build
+    //      (called to build prod, nightly and develop.element.io)
+    // arg.mode is set to "delopment" by yarn start
+    //      (called by developers, runs the continuous reload script)
+    // process.env.CI_PACKAGE is set when yarn build is called from scripts/ci_package.sh
+    //      (called to build nightly and develop.element.io)
     const nodeEnv = argv.mode;
     const devMode = nodeEnv !== 'production';
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,17 +40,7 @@ function getActiveThemes() {
 }
 
 module.exports = (env, argv) => {
-    let nodeEnv;
-    if (process.env.CI_PACKAGE) {
-        // More and more people are using nightly build as their main client
-        // Libraries like React have a development build that is useful
-        // when working on the app but adds significant runtime overhead
-        // We want to use the React production build but not compile the whole
-        // application to productions standards
-        nodeEnv = "production";
-    } else {
-        nodeEnv = argv.mode;
-    }
+    const nodeEnv = argv.mode;
     const devMode = nodeEnv !== 'production';
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;
     const fullPageErrors = process.env.FULL_PAGE_ERRORS === '1' && devMode;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,6 @@ module.exports = (env, argv) => {
         // We override this via environment variable to avoid duplicating the scripts
         // in `package.json` just for a different mode.
         argv.mode = "development";
-
         // More and more people are using nightly build as their main client
         // Libraries like React have a development build that is useful
         // when working on the app but adds significant runtime overhead
@@ -57,9 +56,11 @@ module.exports = (env, argv) => {
     const devMode = nodeEnv !== 'production';
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;
     const fullPageErrors = process.env.FULL_PAGE_ERRORS === '1' && devMode;
+    const enableMinification = argv.mode === "production";
+    const enableSourceMaps = argv.mode === "production";
 
     const development = {};
-    if (argv.mode === "production") {
+    if (enableSourceMaps) {
         development['devtool'] = 'nosources-source-map';
     } else {
         // This makes the sourcemaps human readable for developers. We use eval-source-map
@@ -126,8 +127,8 @@ module.exports = (env, argv) => {
 
             // Minification is normally enabled by default for webpack in production mode, but
             // we use a CSS optimizer too and need to manage it ourselves.
-            minimize: argv.mode === 'production',
-            minimizer: argv.mode === 'production' ? [new TerserPlugin({}), new OptimizeCSSAssetsPlugin({})] : [],
+            minimize: enableMinification,
+            minimizer: enableMinification ? [new TerserPlugin({}), new OptimizeCSSAssetsPlugin({})] : [],
 
             // Set the value of `process.env.NODE_ENV` for libraries like React
             // See also https://v4.webpack.js.org/configuration/optimization/#optimizationnodeenv
@@ -540,7 +541,7 @@ module.exports = (env, argv) => {
             process.env.SENTRY_DSN &&
                 new SentryCliPlugin({
                     release: process.env.VERSION,
-                    include: "./webapp",
+                    include: "./webapp/bundles",
                 }),
             new webpack.EnvironmentPlugin(['VERSION']),
         ].filter(Boolean),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = (env, argv) => {
     const devMode = nodeEnv !== 'production';
     const useHMR = process.env.CSS_HOT_RELOAD === '1' && devMode;
     const fullPageErrors = process.env.FULL_PAGE_ERRORS === '1' && devMode;
-    const enableMinification = argv.mode === "production";
+    const enableMinification = !devMode;
 
     const development = {};
     if (devMode) {


### PR DESCRIPTION
With previous settings, our JS files for develop are so large that sentry's webserver rejects the upload.

In this change - 

* re-enable minification to reduce the size of the files
* update the CI sourcemap setting from `eval-source-map` to `source-map` to move the embedded source out of the .js payload and into .js.map files

This step fixed the issue for me locally at least by reducing the size of `init.js` from ~25MB to a 2MB js + 10MB .map

This PR also includes a careful refactor of the loading of build config depending on the args and environment, its best to follow this commit by commit.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->