### PR TITLE
Reference commits instead of tags in workflows

### DIFF
--- a/.github/workflows/triage-incoming.yml
+++ b/.github/workflows/triage-incoming.yml
@@ -8,7 +8,7 @@ jobs:
   automate-project-columns:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: alex-page/github-project-automation-plus@bb266ff4dde9242060e2d5418e120a133586d488
         with:
           project: Issue triage
           column: Incoming

--- a/.github/workflows/triage-move-labelled.yml
+++ b/.github/workflows/triage-move-labelled.yml
@@ -9,7 +9,7 @@ jobs:
     name: Move X-Needs-Info issues to Need info on triage board
     runs-on: ubuntu-latest
     steps:
-    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+    - uses: konradpabjan/move-labeled-or-milestoned-issue@219d384e03fa4b6460cd24f9f37d19eb033a4338
       with:
         action-token: ${{ secrets.GITHUB_TOKEN }}
         project-url: "https://github.com/vector-im/element-web/projects/27"
@@ -27,7 +27,7 @@ jobs:
          contains(github.event.issue.labels.*.name, 'S-Major') ||
          contains(github.event.issue.labels.*.name, 'S-Minor'))
     steps:
-      - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      - uses: konradpabjan/move-labeled-or-milestoned-issue@219d384e03fa4b6460cd24f9f37d19eb033a4338
         with:
           action-token: "${{ secrets.ELEMENT_BOT_TOKEN }}"
           project-url: "https://github.com/orgs/vector-im/projects/14"
@@ -42,7 +42,7 @@ jobs:
         contains(github.event.issue.labels.*.name, 'A-Space-Settings') ||
         contains(github.event.issue.labels.*.name, 'A-Subspaces')
     steps:
-      - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      - uses: konradpabjan/move-labeled-or-milestoned-issue@219d384e03fa4b6460cd24f9f37d19eb033a4338
         with:
           action-token: "${{ secrets.ELEMENT_BOT_TOKEN }}"
           project-url: "https://github.com/orgs/vector-im/projects/6"

--- a/.github/workflows/triage-move-unlabelled.yml
+++ b/.github/workflows/triage-move-unlabelled.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.project_card.project_card.column_id == 16669398) &&
         !contains(github.event.issue.labels.*.name, 'X-Needs-Info') }}
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: alex-page/github-project-automation-plus@bb266ff4dde9242060e2d5418e120a133586d488
         with:
           project: Issue triage
           column: Triaged

--- a/.github/workflows/triage-priority-bugs.yml
+++ b/.github/workflows/triage-priority-bugs.yml
@@ -25,7 +25,7 @@ jobs:
          contains(github.event.issue.labels.*.name, 'A11y') &&
          contains(github.event.issue.labels.*.name, 'O-Frequent'))
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: alex-page/github-project-automation-plus@bb266ff4dde9242060e2d5418e120a133586d488
         with:
           project: Web App Team
           column: P1


### PR DESCRIPTION
This is better in case the tag is ever assigned to another commit.

Signed-off-by: Ekaterina Gerasimova <ekaterinag@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->