### PR TITLE
Workflow: use our special token instead of github

### DIFF
--- a/.github/workflows/triage-move-labelled.yml
+++ b/.github/workflows/triage-move-labelled.yml
@@ -9,12 +9,12 @@ jobs:
     name: Move X-Needs-Info issues to Need info on triage board
     runs-on: ubuntu-latest
     steps:
-    - uses: konradpabjan/move-labeled-or-milestoned-issue@219d384e03fa4b6460cd24f9f37d19eb033a4338
-      with:
-        action-token: ${{ secrets.GITHUB_TOKEN }}
-        project-url: "https://github.com/vector-im/element-web/projects/27"
-        column-name: "Need info"
-        label-name: "X-Needs-Info"
+      - uses: konradpabjan/move-labeled-or-milestoned-issue@219d384e03fa4b6460cd24f9f37d19eb033a4338
+        with:
+          action-token: "${{ secrets.ELEMENT_BOT_TOKEN }}"
+          project-url: "https://github.com/vector-im/element-web/projects/27"
+          column-name: "Need info"
+          label-name: "X-Needs-Info"
 
   move_priority_design_issues:
     name: Move priority X-Needs-Design issues to Design project board


### PR DESCRIPTION
This could fix the obscure "#ERROR# HttpError: Validation Failed" that
we're getting in failed actions.

Signed-off-by: Ekaterina Gerasimova <ekaterinag@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->