### PR TITLE
Update triage workflow to fix conditional

### DIFF
--- a/.github/workflows/triage-move-labelled.yml
+++ b/.github/workflows/triage-move-labelled.yml
@@ -83,8 +83,7 @@ jobs:
     name: Move A-Voice Messages to Voice message board
     runs-on: ubuntu-latest
     if: >
-        ${{
-        contains(github.event.issue.labels.*.name, 'A-Voice Messages') }}
+        contains(github.event.issue.labels.*.name, 'A-Voice Messages')
     steps:
       - uses: konradpabjan/move-labeled-or-milestoned-issue@219d384e03fa4b6460cd24f9f37d19eb033a4338
         with:


### PR DESCRIPTION
Docs say to use curly brackets, internet says that can break
multiline conditionals.

Trying to fix the if statement applying only to the first step in the job and
the second step ignoring the conditional.

Signed-off-by: Ekaterina Gerasimova <ekaterinag@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->