### PR TITLE
Get version from build VERSION variable

### DIFF
--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -33,8 +33,6 @@ import { logger } from "matrix-js-sdk/src/logger";
 const POKE_RATE_MS = 10 * 60 * 1000; // 10 min
 
 export default class WebPlatform extends VectorBasePlatform {
-    private runningVersion: string = null;
-
     constructor() {
         super();
         // Register service worker if available on this platform
@@ -102,7 +100,7 @@ export default class WebPlatform extends VectorBasePlatform {
         return notification;
     }
 
-    private getVersion(): Promise<string> {
+    private getMostRecentVersion(): Promise<string> {
         // We add a cachebuster to the request to make sure that we know about
         // the most recent version on the origin server. That might not
         // actually be the version we'd get on a reload (particularly in the
@@ -144,12 +142,10 @@ export default class WebPlatform extends VectorBasePlatform {
     }
 
     pollForUpdate = () => {
-        return this.getVersion().then((ver) => {
-            if (this.runningVersion === null) {
-                this.runningVersion = ver;
-            } else if (this.runningVersion !== ver) {
-                if (this.shouldShowUpdate(ver)) {
-                    showUpdateToast(this.runningVersion, ver);
+        return this.getMostRecentVersion() .then((mostRecentVersion) => {
+            if (process.env.VERSION !== mostRecentVersion) {
+                if (this.shouldShowUpdate(mostRecentVersion)) {
+                    showUpdateToast(process.env.VERSION, mostRecentVersion);
                 }
                 return { status: UpdateCheckStatus.Ready };
             } else {

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -129,7 +129,15 @@ export default class WebPlatform extends VectorBasePlatform {
     }
 
     getAppVersion(): Promise<string> {
-        return Promise.resolve(process.env.VERSION);
+        let ver = process.env.VERSION;
+
+        // if version looks like semver with leading v, strip it
+        // (matches scripts/package.sh)
+        const semVerRegex = new RegExp("^v[0-9]+.[0-9]+.[0-9]+(-.+)?$");
+        if (semVerRegex.test(process.env.VERSION)) {
+            ver = process.env.VERSION.substr(1);
+        }
+        return Promise.resolve(ver);
     }
 
     startUpdater() {

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -131,10 +131,7 @@ export default class WebPlatform extends VectorBasePlatform {
     }
 
     getAppVersion(): Promise<string> {
-        if (this.runningVersion !== null) {
-            return Promise.resolve(this.runningVersion);
-        }
-        return this.getVersion();
+        return Promise.resolve(process.env.VERSION);
     }
 
     startUpdater() {

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -150,7 +150,7 @@ export default class WebPlatform extends VectorBasePlatform {
     }
 
     pollForUpdate = () => {
-        return this.getMostRecentVersion() .then((mostRecentVersion) => {
+        return this.getMostRecentVersion().then((mostRecentVersion) => {
             if (process.env.VERSION !== mostRecentVersion) {
                 if (this.shouldShowUpdate(mostRecentVersion)) {
                     showUpdateToast(process.env.VERSION, mostRecentVersion);


### PR DESCRIPTION
For the web platform, rather than fetching the version of the app from a file on the server which it was downloaded from, fetch it from process.env.VERSION which is set at compile time.

This ensures that the version actually reflects the bundle which is currently running; this isn't necessarily true otherwise, consider after an update when the static files have been updated but the browser is still running an old version.

It also means we don't have to wait for a network request just to get the app's version.

The file this was previously fetched from is written during packaging at https://github.com/vector-im/element-web/blob/develop/scripts/package.sh#L25 - it's the same `VERSION` build variable but stripped of leading `v` if its a semver, which we replicate at runtime

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->