### PR TITLE
Normalize the local app version when checking for updates

### DIFF
--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -128,7 +128,7 @@ export default class WebPlatform extends VectorBasePlatform {
         });
     }
 
-    getAppVersion(): Promise<string> {
+    getNormalizedAppVersion(): string {
         let ver = process.env.VERSION;
 
         // if version looks like semver with leading v, strip it
@@ -137,7 +137,11 @@ export default class WebPlatform extends VectorBasePlatform {
         if (semVerRegex.test(process.env.VERSION)) {
             ver = process.env.VERSION.substr(1);
         }
-        return Promise.resolve(ver);
+        return ver;
+    }
+
+    getAppVersion(): Promise<string> {
+        return Promise.resolve(this.getNormalizedAppVersion());
     }
 
     startUpdater() {
@@ -151,9 +155,11 @@ export default class WebPlatform extends VectorBasePlatform {
 
     pollForUpdate = () => {
         return this.getMostRecentVersion().then((mostRecentVersion) => {
-            if (process.env.VERSION !== mostRecentVersion) {
+            const currentVersion = this.getNormalizedAppVersion();
+
+            if (currentVersion !== mostRecentVersion) {
                 if (this.shouldShowUpdate(mostRecentVersion)) {
-                    showUpdateToast(process.env.VERSION, mostRecentVersion);
+                    showUpdateToast(currentVersion, mostRecentVersion);
                 }
                 return { status: UpdateCheckStatus.Ready };
             } else {


### PR DESCRIPTION
We need to strip the leading v from the local app version in `pollForUpdate` to ensure it compares correctly the version from the `/version` request indicating what the latest available version is. Previously, we only stripped the leading in `getAppVersion` which is used in some other places but not to decide whether an update is available.

Fixes https://github.com/vector-im/element-web/issues/20058

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->