### PR TITLE
Fix Docker build versioning (#20077)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,11 @@ WORKDIR /src
 COPY . /src
 RUN dos2unix /src/scripts/docker-link-repos.sh && bash /src/scripts/docker-link-repos.sh
 RUN yarn --network-timeout=100000 install
-RUN yarn build
+
+RUN dos2unix /src/scripts/docker-package.sh && bash /src/scripts/docker-package.sh
 
 # Copy the config now so that we don't create another layer in the app image
 RUN cp /src/config.sample.json /src/webapp/config.json
-
-# Ensure we populate the version file
-RUN dos2unix /src/scripts/docker-write-version.sh && bash /src/scripts/docker-write-version.sh
-
 
 # App
 FROM nginx:alpine

--- a/scripts/ci_package.sh
+++ b/scripts/ci_package.sh
@@ -1,17 +1,11 @@
 #!/bin/bash
 
-# Runs package.sh setting the version to git hashes of the element-web,
-# react-sdk & js-sdk checkouts, for the case where these dependencies
-# are git checkouts.
+# Runs package.sh, passing DIST_VERSION determined by git
 
 set -ex
 
 rm dist/element-*.tar.gz || true # rm previous artifacts without failing if it doesn't exist
 
-# Since the deps are fetched from git, we can rev-parse
-REACT_SHA=$(cd node_modules/matrix-react-sdk; git rev-parse --short=12 HEAD)
-JSSDK_SHA=$(cd node_modules/matrix-js-sdk; git rev-parse --short=12 HEAD)
+DIST_VERSION=`$(dirname $0)/get-version-from-git.sh`
 
-VECTOR_SHA=$(git rev-parse --short=12 HEAD) # use the ACTUAL SHA rather than assume develop
-
-CI_PACKAGE=true DIST_VERSION=$VECTOR_SHA-react-$REACT_SHA-js-$JSSDK_SHA scripts/package.sh
+CI_PACKAGE=true DIST_VERSION=$DIST_VERSION scripts/package.sh

--- a/scripts/docker-package.sh
+++ b/scripts/docker-package.sh
@@ -13,10 +13,9 @@ DIST_VERSION=$TAG
 # for an appropriately tagged branch as well (heads/v1.2.3).
 if [[ $BRANCH != HEAD && ! $BRANCH =~ heads/v.+ ]]
 then
-    REACT_SHA=$(cd node_modules/matrix-react-sdk; git rev-parse --short=12 HEAD)
-    JSSDK_SHA=$(cd node_modules/matrix-js-sdk; git rev-parse --short=12 HEAD)
-    VECTOR_SHA=$(git rev-parse --short=12 HEAD) # use the ACTUAL SHA rather than assume develop
-    DIST_VERSION=$VECTOR_SHA-react-$REACT_SHA-js-$JSSDK_SHA
+    DIST_VERSION=`$(dirname $0)/get-version-from-git.sh`
 fi
 
+DIST_VERSION=`$(dirname $0)/normalize-version.sh ${DIST_VERSION}`
+VERSION=$DIST_VERSION yarn build
 echo $DIST_VERSION > /src/webapp/version

--- a/scripts/get-version-from-git.sh
+++ b/scripts/get-version-from-git.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Echoes a version based on the git hashes of the element-web, react-sdk & js-sdk checkouts, for the case where
+# these dependencies are git checkouts.
+
+# Since the deps are fetched from git, we can rev-parse
+REACT_SHA=$(cd node_modules/matrix-react-sdk; git rev-parse --short=12 HEAD)
+JSSDK_SHA=$(cd node_modules/matrix-js-sdk; git rev-parse --short=12 HEAD)
+VECTOR_SHA=$(git rev-parse --short=12 HEAD) # use the ACTUAL SHA rather than assume develop
+echo $VECTOR_SHA-react-$REACT_SHA-js-$JSSDK_SHA

--- a/scripts/normalize-version.sh
+++ b/scripts/normalize-version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# If $1 looks like v1.2.3 or v1.2.3-foo, strip the leading v, then print it to stdout
+if [[ $1 =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?$ ]]; then
+    echo ${1:1}
+else
+    echo $1
+fi

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -21,12 +21,7 @@ cp -r webapp element-$version
 # Just in case you have a local config, remove it before packaging
 rm element-$version/config.json || true
 
-# if $version looks like semver with leading v, strip it before writing to file
-if [[ ${version} =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?$ ]]; then
-    echo ${version:1} > element-$version/version
-else
-    echo ${version} > element-$version/version
-fi
+$(dirname $0)/normalize-version.sh ${version} > element-$version/version
 
 tar chvzf dist/element-$version.tar.gz element-$version
 rm -r element-$version

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -107,7 +107,7 @@ export default class WebPlatform extends VectorBasePlatform {
         // presence of intermediate caching proxies), but still: we're trying
         // to tell the user that there is a new version.
 
-        return new Promise(function(resolve, reject) {
+        return new Promise((resolve, reject) => {
             request(
                 {
                     method: "GET",
@@ -121,27 +121,24 @@ export default class WebPlatform extends VectorBasePlatform {
                         return;
                     }
 
-                    const ver = body.trim();
-                    resolve(ver);
+                    resolve(this.getNormalizedAppVersion(body.trim()));
                 },
             );
         });
     }
 
-    getNormalizedAppVersion(): string {
-        let ver = process.env.VERSION;
-
+    getNormalizedAppVersion(version: string): string {
         // if version looks like semver with leading v, strip it
-        // (matches scripts/package.sh)
+        // (matches scripts/normalize-version.sh)
         const semVerRegex = new RegExp("^v[0-9]+.[0-9]+.[0-9]+(-.+)?$");
-        if (semVerRegex.test(process.env.VERSION)) {
-            ver = process.env.VERSION.substr(1);
+        if (semVerRegex.test(version)) {
+            return version.substr(1);
         }
-        return ver;
+        return version;
     }
 
     getAppVersion(): Promise<string> {
-        return Promise.resolve(this.getNormalizedAppVersion());
+        return Promise.resolve(this.getNormalizedAppVersion(process.env.VERSION));
     }
 
     startUpdater() {
@@ -155,7 +152,7 @@ export default class WebPlatform extends VectorBasePlatform {
 
     pollForUpdate = () => {
         return this.getMostRecentVersion().then((mostRecentVersion) => {
-            const currentVersion = this.getNormalizedAppVersion();
+            const currentVersion = this.getNormalizedAppVersion(process.env.VERSION);
 
             if (currentVersion !== mostRecentVersion) {
                 if (this.shouldShowUpdate(mostRecentVersion)) {


### PR DESCRIPTION
Push https://github.com/vector-im/element-web/pull/20077 to release-v1.9.6 branch

Note this release has already gone out, but for the parts of the change which affect the Docker build only, we can update without needing to do a hotfix of app.element.io 

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->