### PR TITLE
Fix git protocol usage for CI

### DIFF
--- a/scripts/fetch-develop.deps.sh
+++ b/scripts/fetch-develop.deps.sh
@@ -25,7 +25,7 @@ function clone() {
     if [ -n "$branch" ]
     then
         echo "Trying to use $org/$repo#$branch"
-        git clone git://github.com/$org/$repo.git $repo --branch $branch \
+        git clone https://github.com/$org/$repo.git $repo --branch $branch \
             "${GIT_CLONE_ARGS[@]}"
         return $?
     fi


### PR DESCRIPTION
Prevents this:
```
+ git clone git://github.com/matrix-org/matrix-js-sdk.git matrix-js-sdk --branch develop --depth 1
Cloning into 'matrix-js-sdk'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->