### PR TITLE
Added a workflow to remove Z-Labs label.

### DIFF
--- a/.github/workflows/triage-move-unlabelled.yml
+++ b/.github/workflows/triage-move-unlabelled.yml
@@ -33,3 +33,29 @@ jobs:
           project: Issue triage
           column: Triaged
           repo-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+  remove_Z-Labs_label:
+    name: Remove Z-Labs label when features behind labs flags are removed
+    runs-on: ubuntu-latest
+    if: >
+        !(contains(github.event.issue.labels.*.name, 'A-Maths') || 
+        contains(github.event.issue.labels.*.name, 'A-Message-Pinning') ||
+        contains(github.event.issue.labels.*.name, 'A-Threads') ||
+        contains(github.event.issue.labels.*.name, 'A-Polls') ||
+        contains(github.event.issue.labels.*.name, 'A-Location-Sharing') ||
+        contains(github.event.issue.labels.*.name, 'A-Message-Bubbles') ||
+        contains(github.event.issue.labels.*.name, 'Z-Maximised-Widgets') ||
+        contains(github.event.issue.labels.*.name, 'Z-IA') ||
+        contains(github.event.issue.labels.*.name, 'A-Themes-Custom') ||
+        contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') ||
+        contains(github.event.issue.labels.*.name, 'A-Tags'))
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['Z-Labs']
+            })


### PR DESCRIPTION
Signed-off-by: ankur12-1610 <anknerd.12@gmail.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->
Fixes: #20376

Workflow run:

![remove-label](https://user-images.githubusercontent.com/76884959/148912099-dc6c6429-2915-448a-b6de-9989c0145065.png)




<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->