### PR TITLE
Update default Jitsi URLs to meet.element.io

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -47,6 +47,6 @@
         "breadcrumbs": true
     },
     "jitsi": {
-        "preferredDomain": "jitsi.riot.im"
+        "preferredDomain": "meet.element.io"
     }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -103,7 +103,7 @@ For a good example, see https://develop.element.io/config.json.
 1. `jitsi`: Used to change the default conference options. Learn more about the
    Jitsi options at [jitsi.md](./jitsi.md).
     1. `preferredDomain`: The domain name of the preferred Jitsi instance. Defaults
-       to `jitsi.riot.im`. This is used whenever a user clicks on the voice/video
+       to `meet.element.io`. This is used whenever a user clicks on the voice/video
        call buttons - integration managers may use a different domain.
 1. `enable_presence_by_hs_url`: The property key should be the URL of the homeserver
     and its value defines whether to enable/disable the presence status display

--- a/docs/jitsi.md
+++ b/docs/jitsi.md
@@ -4,10 +4,10 @@ Element uses [Jitsi](https://jitsi.org/) for conference calls, which provides op
 self-hosting your own server and supports most major platforms.
 
 1:1 calls, or calls between you and one other person, do not use Jitsi. Instead, those
-calls work directly between clients or via TURN servers configured on the respective 
+calls work directly between clients or via TURN servers configured on the respective
 homeservers.
 
-There's a number of ways to start a Jitsi call: the easiest way is to click on the 
+There's a number of ways to start a Jitsi call: the easiest way is to click on the
 voice or video buttons near the message composer in a room with more than 2 people. This
 will add a Jitsi widget which allows anyone in the room to join.
 
@@ -30,17 +30,17 @@ to your [config](./config.md) the following:
 }
 ```
 
-The default is `jitsi.riot.im` (a free service offered by Element), and the demo site for
+The default is `meet.element.io` (a free service offered by Element), and the demo site for
 Jitsi uses `meet.jit.si` (also free).
 
 Once you've applied the config change, refresh Element and press the call button. This
-should start a new conference on your Jitsi server. 
+should start a new conference on your Jitsi server.
 
 **Note**: The widget URL will point to a `jitsi.html` page hosted by Element. The Jitsi
 domain will appear later in the URL as a configuration parameter.
 
 **Hint**: If you want everyone on your homeserver to use the same Jitsi server by
-default, and you are using element-web 1.6 or newer, set the following on your homeserver's 
+default, and you are using element-web 1.6 or newer, set the following on your homeserver's
 `/.well-known/matrix/client` config:
 ```json
 {
@@ -55,11 +55,11 @@ default, and you are using element-web 1.6 or newer, set the following on your h
 Element Android (1.0.5+) supports custom Jitsi domains, similar to Element Web above.
 
 1:1 calls, or calls between you and one other person, do not use Jitsi. Instead, those
-calls work directly between clients or via TURN servers configured on the respective 
+calls work directly between clients or via TURN servers configured on the respective
 homeservers.
 
 For rooms with more than 2 joined members, when creating a Jitsi conference via call/video buttons of the toolbar (not via integration manager), Element Android will create a widget using the [wrapper](https://github.com/vector-im/element-web/blob/develop/docs/jitsi-dev.md) hosted on `app.element.io`.
-The domain used is the one specified by the `/.well-known/matrix/client` endpoint, and if not present it uses the fallback defined in `config.xml` (jitsi.riot.im)
+The domain used is the one specified by the `/.well-known/matrix/client` endpoint, and if not present it uses the fallback defined in `config.json` (meet.element.io)
 
 For active Jitsi widgets in the room, a native Jitsi widget UI is created and points to the instance specified in the `domain` key of the widget content data.
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -84,7 +84,7 @@ Then you can deploy it to your cluster with something like `kubectl apply -f my-
                 "breadcrumbs": true
             },
             "jitsi": {
-                "preferredDomain": "jitsi.riot.im"
+                "preferredDomain": "meet.element.io"
             }
         }
 

--- a/scripts/build-jitsi.js
+++ b/scripts/build-jitsi.js
@@ -12,20 +12,20 @@ const ProxyAgent = require("simple-proxy-agent");
 console.log("Making webapp directory");
 mkdirp.sync("webapp");
 
-// curl -s https://jitsi.riot.im/libs/external_api.min.js > ./webapp/jitsi_external_api.min.js
+// curl -s https://meet.element.io/libs/external_api.min.js > ./webapp/jitsi_external_api.min.js
 console.log("Downloading Jitsi script");
 const fname = path.join("webapp", "jitsi_external_api.min.js");
 
 const options = {};
 if (process.env.HTTPS_PROXY) {
-   options.agent = new ProxyAgent(process.env.HTTPS_PROXY, {tunnel: true});
+    options.agent = new ProxyAgent(process.env.HTTPS_PROXY, { tunnel: true });
 }
 
-fetch("https://jitsi.riot.im/libs/external_api.min.js", options).then(res => {
-   const stream = fs.createWriteStream(fname);
-   return new Promise((resolve, reject) => {
-       res.body.pipe(stream);
-       res.body.on('error', err => reject(err));
-       res.body.on('finish', () => resolve());
-   });
+fetch("https://meet.element.io/libs/external_api.min.js", options).then(res => {
+    const stream = fs.createWriteStream(fname);
+    return new Promise((resolve, reject) => {
+        res.body.pipe(stream);
+        res.body.on('error', err => reject(err));
+        res.body.on('finish', () => resolve());
+    });
 }).then(() => console.log('Done with Jitsi download'));


### PR DESCRIPTION
Related https://github.com/matrix-org/matrix-react-sdk/pull/7514


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->