### PR TITLE
Add Cache-Control: no-cache headers for non-bundled files in docker container.

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -6,11 +6,20 @@ server {
     root   /usr/share/nginx/html;
     index  index.html;
 
-    # Set no-cache for the index.html only so that browsers always check for a new copy of Element Web.
+    # Set no-cache for the version, config and index.html
+    # so that browsers always check for a new copy of Element Web.
+    # NB http://your-domain/ and http://your-domain/? are also covered by this
+
     location = /index.html {
         add_header Cache-Control "no-cache";
     }
-
+    location = /version {
+        add_header Cache-Control "no-cache";
+    }
+    # covers config.json and config.hostname.json requests as it is prefix.
+    location /config {
+        add_header Cache-Control "no-cache";
+    }
     # redirect server error pages to the static page /50x.html
     #
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->

These files are the minimal set that should be uncached to help element-web to rapidly respond to config and version updates. We currently only handle the index.html page but we should also look at config.json and version as we will treat these specially on develop.element.io and staging.element.io

This is related to the issue #20033 , where we also needed to make sure these were uncached; i thought we should do it here for completeness too.

To test:
```
# get current latest version
docker pull vectorim/element-web:latest

# Build this new version
docker build -t element-web:nginx-changes .

# Run current latest:
docker run -p 50000:80 vectorim/element-web:latest

# Look for cache headers:
curl -v http://localhost:50000/ > /dev/null # note cache-control: no-cache header is set
curl -v http://localhost:50000/version > /dev/null # note cache-control: no-cache header is NOT set
curl -v http://localhost:50000/config.json > /dev/null # note cache-control: no-cache header is NOT set
curl -v http://localhost:50000/config.localhost.json > /dev/null # default install has this as a 404, so we won't see the cache header here. 

#Stop the old version, run the new version with:
docker run -p 50000:80 element-web:nginx-changes

#Run the above tests and see that the headers are set where expected.
```


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->