### PR TITLE
Update lockfile after release

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8041,9 +8041,10 @@ mathml-tag-names@^2.1.3:
   version "0.0.1"
   resolved "git+https://github.com/matrix-org/matrix-analytics-events.git#1eab4356548c97722a183912fda1ceabbe8cc7c1"
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#develop":
-  version "15.3.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/2d9c93876524cb553f616b10fe50d9e7e539075b"
+matrix-js-sdk@15.4.0:
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-15.4.0.tgz#3bc7638c8c9313f64cf4410e0e83a376facc3e41"
+  integrity sha512-4iFYnIYEzRwM8W+D3wwcpcv3EspxlYgBNZN3pxWUoYqsTL8PnPSsq2wYFWsoKfEt27EEWour5jwEoP8vjlwYOw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     another-json "^0.2.0"
@@ -8064,9 +8065,10 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:matrix-org/matrix-react-sdk#develop":
-  version "3.37.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-react-sdk/tar.gz/ec02f8241637f5e428b45a96bbacbb9fb976bb81"
+matrix-react-sdk@3.38.0:
+  version "3.38.0"
+  resolved "https://registry.yarnpkg.com/matrix-react-sdk/-/matrix-react-sdk-3.38.0.tgz#37c90ecbee562edf7c0772284d2c87ac2b438b44"
+  integrity sha512-Q9bHPRPI/X1MPOknDiFwRbGM4xAyjCTWDEBXTiCoaocL/1n9MJTDKI2DB21Vdhc/ceEYH+8aeYd7JRaxyedLhw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@sentry/browser" "^6.11.0"


### PR DESCRIPTION
It appears that the lockfile is not referencing the latest `matrix-js-sdk` and `matrix-react-sdk` versions.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->