### PR TITLE
Persist jitsi only after meeting is joined

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -218,11 +218,6 @@ function joinConference() { // event handler bound in HTML
 
     switchVisibleContainers();
 
-    if (widgetApi) {
-        // ignored promise because we don't care if it works
-        // noinspection JSIgnoredPromiseFromCall
-        widgetApi.setAlwaysOnScreen(true);
-    }
 
     logger.warn(
         "[Jitsi Widget] The next few errors about failing to parse URL parameters are fine if " +
@@ -251,6 +246,15 @@ function joinConference() { // event handler bound in HTML
     if (avatarUrl) meetApi.executeCommand("avatarUrl", avatarUrl);
     if (userId) meetApi.executeCommand("email", userId);
     if (roomName) meetApi.executeCommand("subject", roomName);
+
+    // fires once when active user joins the conference
+    meetApi.on("videoConferenceJoined", (event) => {
+        if (widgetApi) {
+            // ignored promise because we don't care if it works
+            // noinspection JSIgnoredPromiseFromCall
+            widgetApi.setAlwaysOnScreen(true);
+        }
+    })
 
     meetApi.on("readyToClose", () => {
         switchVisibleContainers();

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -218,7 +218,6 @@ function joinConference() { // event handler bound in HTML
 
     switchVisibleContainers();
 
-
     logger.warn(
         "[Jitsi Widget] The next few errors about failing to parse URL parameters are fine if " +
         "they mention 'external_api' or 'jitsi' in the stack. They're just Jitsi Meet trying to parse " +
@@ -247,14 +246,15 @@ function joinConference() { // event handler bound in HTML
     if (userId) meetApi.executeCommand("email", userId);
     if (roomName) meetApi.executeCommand("subject", roomName);
 
-    // fires once when active user joins the conference
-    meetApi.on("videoConferenceJoined", (event) => {
+    // fires once when user joins the conference
+    // (regardless of video on or off)
+    meetApi.on("videoConferenceJoined", () => {
         if (widgetApi) {
             // ignored promise because we don't care if it works
             // noinspection JSIgnoredPromiseFromCall
             widgetApi.setAlwaysOnScreen(true);
         }
-    })
+    });
 
     meetApi.on("readyToClose", () => {
         switchVisibleContainers();


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Fixes: https://github.com/vector-im/element-web/issues/20637
https://element-io.atlassian.net/browse/PSE-272

Before:
https://user-images.githubusercontent.com/3055605/150136483-b0c9d562-f7fc-4cb3-ad1a-cec6e35c38bb.mov

After:
https://user-images.githubusercontent.com/3055605/150136781-a0df4080-eedb-4804-93f2-810ce987954c.mov


<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->