### PR TITLE
Set app name for UISI autorageshakes in sample config and element.io configs

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -23,6 +23,7 @@
         "https://scalar-staging.riot.im/scalar/api"
     ],
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
+    "uisi_autorageshake_app": "element-auto-uisi",
     "defaultCountryCode": "GB",
     "showLabsSettings": false,
     "features": { },

--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -12,6 +12,7 @@
     ],
     "hosting_signup_link": "https://element.io/matrix-services?utm_source=element-web&utm_medium=web",
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
+    "uisi_autorageshake_app": "element-auto-uisi",
     "showLabsSettings": false,
     "piwik": {
         "url": "https://piwik.riot.im/",

--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -12,6 +12,7 @@
     ],
     "hosting_signup_link": "https://element.io/matrix-services?utm_source=element-web&utm_medium=web",
     "bug_report_endpoint_url": "https://element.io/bugreports/submit",
+    "uisi_autorageshake_app": "element-auto-uisi",
     "showLabsSettings": true,
     "piwik": {
         "url": "https://piwik.riot.im/",


### PR DESCRIPTION
This adds a new setting implemented in matrix-org/matrix-react-sdk#7598 to avoid cluttering the main rageshake repo with UISI autorageshakes.
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->