### PR TITLE
Document the need for yarn build before yarn test

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ pushd matrix-react-sdk
 yarn link
 yarn link matrix-js-sdk
 yarn install
-yarn build
+yarn reskindex
 popd
 ```
 
@@ -380,7 +380,6 @@ There are a number of application-level tests in the `tests` directory; these
 are designed to run with Jest and JSDOM. To run them
 
 ```
-yarn build
 yarn test
 ```
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ git clone https://github.com/matrix-org/matrix-js-sdk.git
 pushd matrix-js-sdk
 yarn link
 yarn install
+yarn build
 popd
 ```
 
@@ -302,6 +303,7 @@ pushd matrix-react-sdk
 yarn link
 yarn link matrix-js-sdk
 yarn install
+yarn build
 popd
 ```
 
@@ -378,6 +380,7 @@ There are a number of application-level tests in the `tests` directory; these
 are designed to run with Jest and JSDOM. To run them
 
 ```
+yarn build
 yarn test
 ```
 

--- a/scripts/docker-link-repos.sh
+++ b/scripts/docker-link-repos.sh
@@ -19,6 +19,8 @@ then
     exit 0
 fi
 
+# These steps correspond with README section "Setting up a dev environment"
+
 echo "Linking js-sdk"
 git clone --depth 1 --branch $JS_SDK_BRANCH $JS_SDK_REPO js-sdk
 cd js-sdk


### PR DESCRIPTION
`yarn test` was failing for me before a build.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->