### PR TITLE
Document jump to date labs feature (MSC3030)

### DIFF
--- a/docs/labs.md
+++ b/docs/labs.md
@@ -31,7 +31,6 @@ Note: This labs feature is only visible when your homeserver has MSC3030 enabled
 Adds a dropdown menu to the date separator headers in the timeline which allows
 you to jump to last week, last month, the beginning of the room, or choose a
 date from the calendar.
-ß
 Also adds the `/jumptodate 2022-01-31` slash command.
 
 ## Custom status (`feature_custom_status`)

--- a/docs/labs.md
+++ b/docs/labs.md
@@ -21,6 +21,19 @@ Enables rendering of LaTeX maths in messages using [KaTeX](https://katex.org/). 
 Allows you to pin messages in the room. To pin a message, use the 3 dots to the right of the message
 and select "Pin".
 
+## Jump to date (`feature_jump_to_date`)
+
+Note: This labs feature is only visible when your homeserver has MSC3030 enabled
+(in Synapse, add `experimental_features` -> `msc3030_enabled` to your
+`homeserver.yaml`) which means `GET /_matrix/client/versions` responds with
+`org.matrix.msc3030` under the `unstable_features` key.
+
+Adds a dropdown menu to the date separator headers in the timeline which allows
+you to jump to last week, last month, the beginning of the room, or choose a
+date from the calendar.
+ß
+Also adds the `/jumptodate 2022-01-31` slash command.
+
 ## Custom status (`feature_custom_status`)
 
 An experimental approach for supporting custom status messages across DMs. To set a status, click on

--- a/docs/labs.md
+++ b/docs/labs.md
@@ -31,6 +31,7 @@ Note: This labs feature is only visible when your homeserver has MSC3030 enabled
 Adds a dropdown menu to the date separator headers in the timeline which allows
 you to jump to last week, last month, the beginning of the room, or choose a
 date from the calendar.
+
 Also adds the `/jumptodate 2022-01-31` slash command.
 
 ## Custom status (`feature_custom_status`)


### PR DESCRIPTION
Document jump to date labs feature

Feature added in:

 - https://github.com/matrix-org/matrix-react-sdk/pull/7339
 - https://github.com/matrix-org/matrix-react-sdk/pull/7372
 - MSC3030: https://github.com/matrix-org/matrix-doc/pull/303

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->