### PR TITLE
Update labs issue labels

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -12,9 +12,7 @@ jobs:
         contains(github.event.issue.labels.*.name, 'A-Maths') || 
         contains(github.event.issue.labels.*.name, 'A-Message-Pinning') ||
         contains(github.event.issue.labels.*.name, 'A-Threads') ||
-        contains(github.event.issue.labels.*.name, 'A-Polls') ||
         contains(github.event.issue.labels.*.name, 'A-Location-Sharing') ||
-        contains(github.event.issue.labels.*.name, 'A-Message-Bubbles') ||
         contains(github.event.issue.labels.*.name, 'Z-IA') ||
         contains(github.event.issue.labels.*.name, 'A-Themes-Custom') ||
         contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') ||


### PR DESCRIPTION
Updates the list of labels behind labs flags to reflect the release of polls and message bubbles.

Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->