### PR TITLE
Create mock implementation of navigator.registerProtocolHandler for jest

### DIFF
--- a/test/jest-mocks.js
+++ b/test/jest-mocks.js
@@ -13,9 +13,7 @@ Object.defineProperty(window, 'matchMedia', {
     })),
 });
 
-Object.defineProperty(navigator, 'registerProtocolHandler', {
-    value: jest.fn().mockImplementation(),
-});
+navigator.registerProtocolHandler = jest.fn();
 
 // maplibre requires a createObjectURL mock
 global.URL.createObjectURL = jest.fn();

--- a/test/jest-mocks.js
+++ b/test/jest-mocks.js
@@ -13,5 +13,9 @@ Object.defineProperty(window, 'matchMedia', {
     })),
 });
 
+Object.defineProperty(navigator, 'registerProtocolHandler', {
+    value: jest.fn().mockImplementation(),
+});
+
 // maplibre requires a createObjectURL mock
 global.URL.createObjectURL = jest.fn();


### PR DESCRIPTION
Maybe this will fix the tests on https://github.com/matrix-org/matrix-react-sdk/pull/7700

Type: task
Notes: none


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->