### PR TITLE
add ComponentVisibility to customisation docs

### DIFF
--- a/docs/customisations.md
+++ b/docs/customisations.md
@@ -34,6 +34,7 @@ chance of merge conflicts when updating your fork, and thus simplify ongoing
 maintenance.
 
 ### Component visibility customisation
+UI for some actions can be hidden via the ComponentVisibility customisation:
 - inviting users to rooms and spaces,
 - creating rooms,
 - creating spaces,
@@ -41,7 +42,8 @@ maintenance.
 To customise visibility create a customisation module from [ComponentVisibility](https://github.com/matrix-org/matrix-react-sdk/blob/master/src/customisations/ComponentVisibility.ts) following the instructions above.
 
 `shouldShowComponent` determines whether or not the active MatrixClient user should be able to use
-the given UI component. If shown, the user might still not be able to use the
+the given UI component. When `shouldShowComponent` returns falsy all UI components for that feature will be hidden.
+If shown, the user might still not be able to use the
 component depending on their contextual permissions. For example, invite options
 might be shown to the user but they won't have permission to invite users to
 the current room: the button will appear disabled.
@@ -56,3 +58,4 @@ function shouldShowComponent(component: UIComponent): boolean {
    return true;
 }
 ```
+In this example, all UI related to creating a space will be hidden unless the users meets a custom condition.

--- a/docs/customisations.md
+++ b/docs/customisations.md
@@ -32,3 +32,27 @@ steps to remove the need for build changes like the above.
 By isolating customisations to their own module, this approach should remove the
 chance of merge conflicts when updating your fork, and thus simplify ongoing
 maintenance.
+
+### Component visibility customisation
+- inviting users to rooms and spaces,
+- creating rooms,
+- creating spaces,
+
+To customise visibility create a customisation module from [ComponentVisibility](https://github.com/matrix-org/matrix-react-sdk/blob/master/src/customisations/ComponentVisibility.ts) following the instructions above.
+
+`shouldShowComponent` determines whether or not the active MatrixClient user should be able to use
+the given UI component. If shown, the user might still not be able to use the
+component depending on their contextual permissions. For example, invite options
+might be shown to the user but they won't have permission to invite users to
+the current room: the button will appear disabled.
+
+For example, to only allow users who meet a certain condition to create spaces:
+```
+function shouldShowComponent(component: UIComponent): boolean {
+   if (component === UIComponent.CreateSpaces) {
+      const userMeetsCondition = <<check your custom condition here>>
+      return userMeetsCondition;
+   }
+   return true;
+}
+```


### PR DESCRIPTION
Signed-off-by: Kerry Archibald <kerrya@element.io>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->
