### PR TITLE
Fix command key missing in keyboard shortcuts tab

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -297,21 +297,21 @@ export default class ElectronPlatform extends VectorBasePlatform {
         if (isMac) {
             registerShortcut("KeyBinding.openUserSettings", CategoryName.NAVIGATION, {
                 default: {
-                    commandKey: true,
+                    metaKey: true,
                     key: Key.COMMA,
                 },
                 displayName: _td("Open user settings"),
             });
             registerShortcut("KeyBinding.previousVisitedRoomOrCommunity", CategoryName.NAVIGATION, {
                 default: {
-                    commandKey: true,
+                    metaKey: true,
                     key: Key.SQUARE_BRACKET_LEFT,
                 },
                 displayName: _td("Previous recently visited room or community"),
             });
             registerShortcut("KeyBinding.nextVisitedRoomOrCommunity", CategoryName.NAVIGATION, {
                 default: {
-                    commandKey: true,
+                    metaKey: true,
                     key: Key.SQUARE_BRACKET_RIGHT,
                 },
                 displayName: _td("Next recently visited room or community"),


### PR DESCRIPTION
Improves https://github.com/vector-im/element-web/issues/21049#issuecomment-1039034559
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix command key missing in keyboard shortcuts tab ([\#21102](https://github.com/vector-im/element-web/pull/21102)). Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->