### PR TITLE
Add a config.json option to skip the built-in Jitsi welcome screen

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -123,7 +123,12 @@ For a good example, see https://develop.element.io/config.json.
   `/.well-known/matrix/client` in its well-known location, and the JSON file
   at that location has a key `m.vector.riot.jitsi`. In this case, the
   configuration found in the well-known location is used instead.
-
+1. `jitsiWidget`: Options to change the built-in Jitsi widget behaviour. `jitsi` controls
+   how the widget gets created, but not how it behaves.
+    1. `skipBuildInWelcomeScreen`: If you'd like to skip the default "Join Conference"
+       behaviour, set this to `true`. This will cause the widget to assume that there's
+       a Jitsi welcome screen set up and point the user towards that. Note that this can
+       cause the camera/microphone to flicker as "in use" while Jitsi tests the devices.
 1. `enable_presence_by_hs_url`: The property key should be the URL of the homeserver
     and its value defines whether to enable/disable the presence status display
     from that homeserver. If no options are configured, presence is shown for all

--- a/docs/config.md
+++ b/docs/config.md
@@ -125,7 +125,7 @@ For a good example, see https://develop.element.io/config.json.
   configuration found in the well-known location is used instead.
 1. `jitsiWidget`: Options to change the built-in Jitsi widget behaviour. `jitsi` controls
    how the widget gets created, but not how it behaves.
-    1. `skipBuildInWelcomeScreen`: If you'd like to skip the default "Join Conference"
+    1. `skipBuiltInWelcomeScreen`: If you'd like to skip the default "Join Conference"
        behaviour, set this to `true`. This will cause the widget to assume that there's
        a Jitsi welcome screen set up and point the user towards that. Note that this can
        cause the camera/microphone to flicker as "in use" while Jitsi tests the devices.


### PR DESCRIPTION
Stop-gap for https://github.com/vector-im/element-web/issues/20503

No tests for this because it's painful, sorry.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add a config.json option to skip the built-in Jitsi welcome screen ([\#21190](https://github.com/vector-im/element-web/pull/21190)).<!-- CHANGELOG_PREVIEW_END -->