### PR TITLE
Mandate use of js-sdk/src/matrix import over js-sdk/src

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,9 @@ module.exports = {
                     "message": "Please use matrix-react-sdk/src/index instead",
                 }],
                 "patterns": [{
+                    "group": ["matrix-js-sdk/lib", "matrix-js-sdk/lib/", "matrix-js-sdk/lib/**"],
+                    "message": "Please use matrix-js-sdk/src/* instead",
+                }, {
                     "group": ["matrix-react-sdk/lib", "matrix-react-sdk/lib/", "matrix-react-sdk/lib/**"],
                     "message": "Please use matrix-react-sdk/src/* instead",
                 }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,24 @@ module.exports = {
 
             // We disable this while we're transitioning
             "@typescript-eslint/no-explicit-any": "off",
+
+            // Ban matrix-js-sdk/src imports in favour of matrix-js-sdk/src/matrix imports to prevent unleashing hell.
+            "no-restricted-imports": ["error", {
+                "name": "matrix-js-sdk",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/src",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/src/",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }, {
+                "name": "matrix-js-sdk/src/index",
+                "message": "Please use matrix-js-sdk/src/matrix instead",
+            }],
         },
     }],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,20 +28,32 @@ module.exports = {
 
             // Ban matrix-js-sdk/src imports in favour of matrix-js-sdk/src/matrix imports to prevent unleashing hell.
             "no-restricted-imports": ["error", {
-                "name": "matrix-js-sdk",
-                "message": "Please use matrix-js-sdk/src/matrix instead",
-            }, {
-                "name": "matrix-js-sdk/",
-                "message": "Please use matrix-js-sdk/src/matrix instead",
-            }, {
-                "name": "matrix-js-sdk/src",
-                "message": "Please use matrix-js-sdk/src/matrix instead",
-            }, {
-                "name": "matrix-js-sdk/src/",
-                "message": "Please use matrix-js-sdk/src/matrix instead",
-            }, {
-                "name": "matrix-js-sdk/src/index",
-                "message": "Please use matrix-js-sdk/src/matrix instead",
+                "paths": [{
+                    "name": "matrix-js-sdk",
+                    "message": "Please use matrix-js-sdk/src/matrix instead",
+                }, {
+                    "name": "matrix-js-sdk/",
+                    "message": "Please use matrix-js-sdk/src/matrix instead",
+                }, {
+                    "name": "matrix-js-sdk/src",
+                    "message": "Please use matrix-js-sdk/src/matrix instead",
+                }, {
+                    "name": "matrix-js-sdk/src/",
+                    "message": "Please use matrix-js-sdk/src/matrix instead",
+                }, {
+                    "name": "matrix-js-sdk/src/index",
+                    "message": "Please use matrix-js-sdk/src/matrix instead",
+                }, {
+                    "name": "matrix-react-sdk",
+                    "message": "Please use matrix-react-sdk/src/index instead",
+                }, {
+                    "name": "matrix-react-sdk/",
+                    "message": "Please use matrix-react-sdk/src/index instead",
+                }],
+                "patterns": [{
+                    "group": ["matrix-react-sdk/lib", "matrix-react-sdk/lib/", "matrix-react-sdk/lib/**"],
+                    "message": "Please use matrix-react-sdk/src/* instead",
+                }],
             }],
         },
     }],

--- a/docs/translating-dev.md
+++ b/docs/translating-dev.md
@@ -30,7 +30,7 @@ function getColorName(hex) {
 
 ## Adding new strings
 
- 1. Check if the import ``import { _t } from 'matrix-react-sdk/lib/languageHandler';`` is present. If not add it to the other import statements. Also import `_td` if needed.
+ 1. Check if the import ``import { _t } from 'matrix-react-sdk/src/languageHandler';`` is present. If not add it to the other import statements. Also import `_td` if needed.
  1. Add ``_t()`` to your string. (Don't forget curly braces when you assign an expression to JSX attributes in the render method). If the string is introduced at a point before the translation system has not yet been initialized, use `_td()` instead, and call `_t()` at the appropriate time.
  1. Run `yarn i18n` to update ``src/i18n/strings/en_EN.json``
  1. If you added a string with a plural, you can add other English plural variants to ``src/i18n/strings/en_EN.json`` (remeber to edit the one in the same project as the source file containing your new translation).

--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -19,7 +19,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import * as sdk from 'matrix-react-sdk';
+import * as sdk from 'matrix-react-sdk/src/index';
 import PlatformPeg from 'matrix-react-sdk/src/PlatformPeg';
 import { _td, newTranslatableError } from 'matrix-react-sdk/src/languageHandler';
 import AutoDiscoveryUtils from 'matrix-react-sdk/src/utils/AutoDiscoveryUtils';

--- a/test/app-tests/joining-test.tsx
+++ b/test/app-tests/joining-test.tsx
@@ -19,7 +19,7 @@ limitations under the License.
 import PlatformPeg from 'matrix-react-sdk/src/PlatformPeg';
 import WebPlatform from '../../src/vector/platform/WebPlatform';
 import * as sdk from "matrix-react-sdk";
-import * as jssdk from "matrix-js-sdk";
+import * as jssdk from "matrix-js-sdk/src/matrix";
 import "../skin-sdk";
 import "../jest-mocks";
 import React from "react";

--- a/test/app-tests/joining-test.tsx
+++ b/test/app-tests/joining-test.tsx
@@ -18,7 +18,7 @@ limitations under the License.
 
 import PlatformPeg from 'matrix-react-sdk/src/PlatformPeg';
 import WebPlatform from '../../src/vector/platform/WebPlatform';
-import * as sdk from "matrix-react-sdk";
+import * as sdk from "matrix-react-sdk/src/index";
 import * as jssdk from "matrix-js-sdk/src/matrix";
 import "../skin-sdk";
 import "../jest-mocks";

--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -25,7 +25,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import MatrixReactTestUtils from 'matrix-react-test-utils';
-import * as jssdk from 'matrix-js-sdk';
+import * as jssdk from 'matrix-js-sdk/src/matrix';
 import * as sdk from 'matrix-react-sdk';
 import {MatrixClientPeg} from 'matrix-react-sdk/src/MatrixClientPeg';
 import {Views} from 'matrix-react-sdk/src/components/structures/MatrixChat';

--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -26,7 +26,7 @@ import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import MatrixReactTestUtils from 'matrix-react-test-utils';
 import * as jssdk from 'matrix-js-sdk/src/matrix';
-import * as sdk from 'matrix-react-sdk';
+import * as sdk from 'matrix-react-sdk/src/index';
 import {MatrixClientPeg} from 'matrix-react-sdk/src/MatrixClientPeg';
 import {Views} from 'matrix-react-sdk/src/components/structures/MatrixChat';
 import dis from 'matrix-react-sdk/src/dispatcher/dispatcher';


### PR DESCRIPTION
Paired with https://github.com/matrix-org/matrix-react-sdk/pull/7933

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->