### PR TITLE
Remove Lojban translation

### DIFF
--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -33,7 +33,6 @@ const INCLUDE_LANGS = [
     {'value': 'is', 'label': 'íslenska'},
     {'value': 'it', 'label': 'Italiano'},
     {'value': 'ja', 'label': '日本語'},
-    {'value': 'jbo', 'label': 'banjubu\'o'},
     {'value': 'kab', 'label': 'Taqbaylit'},
     {'value': 'ko', 'label': '한국어'},
     {'value': 'lt', 'label': 'Lietuvių'},


### PR DESCRIPTION
This was something I did a couple of years ago purely for fun, but it's only bitrotted since then, and it's highly unlikely that anyone has used it (as Lojban is a pretty niche constructed language), so it's a bit silly to keep around.

Type: defect