### PR TITLE
fix webpack path handling for svg imports in electron

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -456,6 +456,7 @@ module.exports = (env, argv) => {
                 },
                 {
                     test: /\.svg$/,
+                    issuer: /\.(js|ts|jsx|tsx|html)$/,
                     use: [
                         {
                             loader: '@svgr/webpack',
@@ -478,10 +479,28 @@ module.exports = (env, argv) => {
                                 outputPath: getAssetOutputPath,
                                 publicPath: function (url, resourcePath) {
                                     const outputPath = getAssetOutputPath(url, resourcePath);
-                                    return toPublicPath(path.join("../..", outputPath));
+                                    return toPublicPath(outputPath);
                                 },
                             },
                         },
+                        {
+                            loader: 'file-loader',
+                            options: {
+                                esModule: false,
+                                name: '[name].[hash:7].[ext]',
+                                outputPath: getAssetOutputPath,
+                                publicPath: function (url, resourcePath) {
+                                    const outputPath = getAssetOutputPath(url, resourcePath);
+                                    return toPublicPath(outputPath);
+                                },
+                            },
+                        },
+                    ]
+                },
+                {
+                    test: /\.svg$/,
+                    issuer: /\.(scss|css)$/,
+                    use: [
                         {
                             loader: 'file-loader',
                             options: {


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Fixes: https://github.com/vector-im/element-web/issues/21293

Electron:
img tag require import left for theme switcher, css import top right buttons
<img width="1035" alt="Screenshot 2022-03-04 at 12 53 20" src="https://user-images.githubusercontent.com/3055605/156759460-82389d67-9d3b-4396-8ca8-47bb4c6e716b.png">
and react component import:

<img width="255" alt="Screenshot 2022-03-04 at 12 53 46" src="https://user-images.githubusercontent.com/3055605/156759454-d9c2c310-6783-4ffd-bfb5-186ac71e42d5.png">


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->