### PR TITLE
Add lint for unused locals

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "target": "es2016",
     "noImplicitAny": false,
+    "noUnusedLocals": true,
     "sourceMap": false,
     "outDir": "./lib",
     "declaration": true,


### PR DESCRIPTION
TypeScript supports checking for "unused locals", which actually includes
locals, private fields, private methods, etc. If a private thing is actually
needed as part of the API surface, you can change it to public to resolve the
error.

This seems like a good check to have, as it highlights unused bits of code that
perhaps got lost while refactoring. This changes our config to reject them and
fixes up a few existing cases.

See also https://github.com/matrix-org/matrix-react-sdk/pull/8007, https://github.com/matrix-org/matrix-js-sdk/pull/2223

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->