### PR TITLE
pin date-fns to 2.27.0 to unbreak `yarn start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "concurrently": "^5.3.0",
     "cpx": "^1.5.0",
     "css-loader": "^3.6.0",
+    "date-fns": "2.27.0",
     "dotenv": "^10.0.0",
     "eslint": "8.9.0",
     "eslint-config-google": "^0.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4236,6 +4236,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
+  integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
+
 date-fns@^2.0.1:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"


### PR DESCRIPTION
Looks like date-fns (a transitive dep of `concurrently`) has broken `require('date-fns/format')` style imports in v2.28.0, and so 'concurrently' fails to run with:

```
 % yarn start
yarn run v1.22.18
$ concurrently --kill-others-on-fail ...
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'date-fns/format'
Require stack:
- /Users/matthew/workspace/element-web/node_modules/concurrently/src/logger.js
```

Therefore, pin it to 2.27.0 for now.

(This is on node v16.14.2 and yarn v1.22.18 on macOS 12.3 on M1)

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->