### PR TITLE
Fix show_labs_settings config.md typo

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -541,4 +541,4 @@ The following are undocumented or intended for developer use only.
 1. `fallback_hs_url`
 2. `sync_timeline_limit`
 3. `dangerously_allow_unsafe_and_insecure_passwords`
-4. `latex_maths_delims`
+4. `latex_maths_delims`: An optional setting to override the default delimiters used for maths parsing. See https://github.com/matrix-org/matrix-react-sdk/pull/5939 for details. Only used when `feature_latex_maths` is enabled.

--- a/docs/config.md
+++ b/docs/config.md
@@ -61,7 +61,7 @@ To force a labs flag on or off, use the following:
 }
 ```
 
-If you'd like the user to be able to self-select which labs flags they can turn on, add `"show_labs_flags": true` to
+If you'd like the user to be able to self-select which labs flags they can turn on, add `"show_labs_settings": true` to
 your config. This will turn on the tab in user settings.
 
 **Note**: Feature support varies release-by-release. Check the [labs flag documentation](./labs.md) frequently if enabling


### PR DESCRIPTION
Fix typo with `show_labs_settings` and document the optional `latex_maths_delims` developer option.

Signed-off-by: Sven Mäder <maeder@phys.ethz.ch>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->