### PR TITLE
Ensure updated=1 is set as the query string before any #

### DIFF
--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -142,14 +142,15 @@ export default class WebPlatform extends VectorBasePlatform {
 
             // Set updated=1 as a query param so we can detect that we've already done this once
             // and reload the page.
-            let suffix = "updated=1";
-            if (window.location.search.length === 0) {
-                suffix = "?" + suffix;
+            const url = new URL(window.location.href);
+            const suffix = "updated=1";
+            if (url.search.length === 0) {
+                url.search = suffix;
             } else {
-                suffix = "&" + suffix;
+                url.search = "&" + suffix;
             }
 
-            reloadPage(window.location.href + suffix);
+            reloadPage(url.toString());
         });
         setInterval(() => this.pollForUpdate(showUpdateToast, hideUpdateToast), POKE_RATE_MS);
     }


### PR DESCRIPTION
This fixes the previous logic when the URL being reloaded contains a #