### PR TITLE
Add automation for "A-New-Search-Experience" label

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -1,4 +1,4 @@
-name: Move labelled issues to correct boards and columns
+name: Move labelled issues to correct projects
 
 on:
   issues:
@@ -11,6 +11,7 @@ jobs:
     if: >
         contains(github.event.issue.labels.*.name, 'A-Maths') || 
         contains(github.event.issue.labels.*.name, 'A-Message-Pinning') ||
+        contains(github.event.issue.labels.*.name, 'A-New-Search-Experience') ||
         contains(github.event.issue.labels.*.name, 'A-Threads') ||
         contains(github.event.issue.labels.*.name, 'A-Location-Sharing') ||
         contains(github.event.issue.labels.*.name, 'Z-IA') ||
@@ -99,6 +100,7 @@ jobs:
     name: Delight issues to project board
     runs-on: ubuntu-latest
     if: >
+        contains(github.event.issue.labels.*.name, 'A-New-Search-Experience') ||
         contains(github.event.issue.labels.*.name, 'A-Spaces') ||
         contains(github.event.issue.labels.*.name, 'A-Space-Settings') ||
         contains(github.event.issue.labels.*.name, 'A-Subspaces') ||


### PR DESCRIPTION
Add A-New-Search-Experience label for automation to Delight board and to add Z-Labs label.

This label is currently down as A-Spotlight-Search, but I will rename it.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->
