### PR TITLE
Fix stuck persistence of Jitsi widgets

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -361,7 +361,7 @@ function joinConference() { // event handler bound in HTML
             // can cause the receiving side to instantly stop listening.
             // ignored promise because we don't care if it works
             // noinspection JSIgnoredPromiseFromCall
-            widgetApi.transport.send(ElementWidgetActions.HangupCall, {}).then(() =>
+            widgetApi.transport.send(ElementWidgetActions.HangupCall, {}).finally(() =>
                 widgetApi.setAlwaysOnScreen(false),
             );
         }


### PR DESCRIPTION
The hangup event may or may not be handled, so we need to account for
cases where it throws an error.

Type: defect

Notes: none

Closes https://github.com/vector-im/element-web/issues/21648.

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->