### PR TITLE
Avoid flashing the Jitsi prejoin screen at the user before skipping it

### DIFF
--- a/src/vector/jitsi/index.scss
+++ b/src/vector/jitsi/index.scss
@@ -56,6 +56,10 @@ body, html {
     position: absolute;
     height: 100%;
     width: 100%;
+
+    // Hidden by default to avoid flashing the prejoin screen at the user when
+    // we're supposed to skip it anyways
+    visibility: hidden;
 }
 
 .joinConferenceFloating {

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -129,11 +129,9 @@ const ack = (ev: CustomEvent<IWidgetApiRequest>) => widgetApi.transport.reply(ev
         skipOurWelcomeScreen = (new SnakedObject<IConfigOptions["jitsi_widget"]>(jitsiConfig))
             .get("skip_built_in_welcome_screen") || isVideoChannel;
 
-        // If we're meant to skip our screen, skip to the part where we show Jitsi instead of us.
+        // Either reveal the prejoin screen, or skip straight to Jitsi depending on the config.
         // We don't set up the call yet though as this might lead to failure without the widget API.
-        if (skipOurWelcomeScreen) {
-            toggleConferenceVisibility(true);
-        }
+        toggleConferenceVisibility(skipOurWelcomeScreen);
 
         if (widgetApi) {
             await readyPromise;


### PR DESCRIPTION
This is important for video rooms, which always skip the prejoin screen.

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Avoid flashing the Jitsi prejoin screen at the user before skipping it ([\#21665](https://github.com/vector-im/element-web/pull/21665)).<!-- CHANGELOG_PREVIEW_END -->