### PR TITLE
When auto-reloading, pass the new version in the updated param to attempt to cachebust

### DIFF
--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -131,7 +131,7 @@ export default class WebPlatform extends VectorBasePlatform {
         console.log("startUpdater, current version is " + this.getNormalizedAppVersion(process.env.VERSION));
         this.pollForUpdate((version: string, newVersion: string) => {
             const query = parseQs(location);
-            if (query.updated === "1") {
+            if (query.updated) {
                 console.log("Update reloaded but still on an old version, stopping");
                 // We just reloaded already and are still on the old version!
                 // Show the toast rather than reload in a loop.
@@ -139,10 +139,10 @@ export default class WebPlatform extends VectorBasePlatform {
                 return;
             }
 
-            // Set updated=1 as a query param so we can detect that we've already done this once
-            // and reload the page.
+            // Set updated as a cachebusting query param and reload the page.
             const url = new URL(window.location.href);
-            url.searchParams.set("updated", "1");
+            url.searchParams.set("updated", newVersion);
+            console.log("Update reloading to " + url.toString());
             window.location.href = url.toString();
         });
         setInterval(() => this.pollForUpdate(showUpdateToast, hideUpdateToast), POKE_RATE_MS);


### PR DESCRIPTION
Firefox is now auto-reloading when it detects a stale version, but it still doesn't seem to be pulling a new copy of the page from the cache.

Try passing the new version as the valued of `updated` to see if it'll bust the cache.

Another change attempting to resolve [9422](https://github.com/vector-im/element-web/issues/9422)

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->