### PR TITLE
Fix Jitsi Meet getting wedged at startup in some cases

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -331,6 +331,10 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
             audioInput: audioDevice,
             videoInput: videoDevice,
         },
+        userInfo: {
+            displayName,
+            email: userId,
+        },
         interfaceConfigOverwrite: {
             SHOW_JITSI_WATERMARK: false,
             SHOW_WATERMARK_FOR_GUESTS: false,
@@ -338,6 +342,7 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
             VIDEO_LAYOUT_FIT: "height",
         },
         configOverwrite: {
+            subject: roomName,
             startAudioOnly,
             startWithAudioMuted: !audioDevice,
             startWithVideoMuted: !videoDevice,
@@ -359,14 +364,12 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
     }
 
     meetApi = new JitsiMeetExternalAPI(jitsiDomain, options);
-    if (displayName) meetApi.executeCommand("displayName", displayName);
-    if (avatarUrl) meetApi.executeCommand("avatarUrl", avatarUrl);
-    if (userId) meetApi.executeCommand("email", userId);
-    if (roomName) meetApi.executeCommand("subject", roomName);
 
     // fires once when user joins the conference
     // (regardless of video on or off)
     meetApi.on("videoConferenceJoined", () => {
+        if (avatarUrl) meetApi.executeCommand("avatarUrl", avatarUrl);
+
         if (widgetApi) {
             // ignored promise because we don't care if it works
             // noinspection JSIgnoredPromiseFromCall


### PR DESCRIPTION
In rare cases with certain deployments, Jitsi Meet would explode upon setting the display name, due to these commands racing with the app's startup.

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix Jitsi Meet getting wedged at startup in some cases ([\#21995](https://github.com/vector-im/element-web/pull/21995)).<!-- CHANGELOG_PREVIEW_END -->