### PR TITLE
Fully close Jitsi conferences on errors

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -301,6 +301,15 @@ async function notifyHangup() {
     }
 }
 
+function closeConference() {
+    switchVisibleContainers();
+    document.getElementById("jitsiContainer").innerHTML = "";
+
+    if (skipOurWelcomeScreen) {
+        skipToJitsiSplashScreen();
+    }
+}
+
 // event handler bound in HTML
 function joinConference(audioDevice?: string, videoDevice?: string) {
     let jwt;
@@ -386,20 +395,15 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
         meetApi = null;
     });
 
-    meetApi.on("readyToClose", () => {
-        switchVisibleContainers();
-        document.getElementById("jitsiContainer").innerHTML = "";
-
-        if (skipOurWelcomeScreen) {
-            skipToJitsiSplashScreen();
-        }
-    });
+    meetApi.on("readyToClose", closeConference);
 
     meetApi.on("errorOccurred", ({ error }) => {
         if (error.isFatal) {
             // We got disconnected. Since Jitsi Meet might send us back to the
             // prejoin screen, we're forced to act as if we hung up entirely.
             notifyHangup();
+            meetApi = null;
+            closeConference();
         }
     });
 


### PR DESCRIPTION
By not closing Jitsi fully when an error occurs, it could get stuck in PiP mode with no way to dismiss.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fully close Jitsi conferences on errors ([\#22060](https://github.com/vector-im/element-web/pull/22060)).<!-- CHANGELOG_PREVIEW_END -->