### PR TITLE
Fix video rooms sometimes connecting muted when they shouldn't

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -355,8 +355,8 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
         configOverwrite: {
             subject: roomName,
             startAudioOnly,
-            startWithAudioMuted: !audioDevice,
-            startWithVideoMuted: !videoDevice,
+            startWithAudioMuted: audioDevice == null,
+            startWithVideoMuted: videoDevice == null,
         } as any,
         jwt: jwt,
     };


### PR DESCRIPTION
Device labels can be blank, which makes them falsy even though they're still a valid device.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix video rooms sometimes connecting muted when they shouldn't ([\#22125](https://github.com/vector-im/element-web/pull/22125)).<!-- CHANGELOG_PREVIEW_END -->