### PR TITLE
add header script-src www.gstatic.cn

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="
         default-src 'none';
         style-src 'self' 'unsafe-inline';
-        script-src 'self' 'unsafe-eval' https://www.recaptcha.net https://www.gstatic.com;
+        script-src 'self' 'unsafe-eval' https://www.recaptcha.net https://www.gstatic.com https://www.gstatic.cn;
         img-src * blob: data:;
         connect-src *;
         font-src 'self' data:;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/12137

add header script-src www.gstatic.cn for google china recaptcha support

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->