### PR TITLE
Update weblateToCounterpart to be more resilient

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -44,7 +44,10 @@ jobs:
           files_ignore: |
             src/i18n/strings/en_EN.json
       - name: "Assert only en_EN was modified"
-        if: github.event_name == 'pull_request' && steps.changed_files.outputs.any_modified == 'true'
+        if: |
+          github.event_name == 'pull_request' &&
+          github.actor != 'RiotTranslateBot' &&
+          steps.changed_files.outputs.any_modified == 'true'
         run: |
           echo "You can only modify en_EN.json, do not touch any of the other i18n files as Weblate will be confused"
           exit 1

--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -232,8 +232,14 @@ function weblateToCounterpart(inTrs) {
         if (keyParts.length === 2) {
             let obj = outTrs[keyParts[0]];
             if (obj === undefined) {
-                obj = {};
-                outTrs[keyParts[0]] = obj;
+                obj = outTrs[keyParts[0]] = {};
+            } else if (typeof obj === "string") {
+                // This is a transitional edge case if a string went from singular to pluralised and both still remain
+                // in the translation json file. Use the singular translation as `other` and merge pluralisation atop.
+                obj = outTrs[keyParts[0]] = {
+                    "other": inTrs[key],
+                };
+                console.warn("Found entry in i18n file in both singular and pluralised form", keyParts[0]);
             }
             obj[keyParts[1]] = inTrs[key];
         } else {


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->