### PR TITLE
Remove stale release.sh parameter for no-jsdoc

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -43,7 +43,7 @@ do
     fi
 done
 
-./node_modules/matrix-js-sdk/release.sh -n -z "$orig_args"
+./node_modules/matrix-js-sdk/release.sh -n "$orig_args"
 
 release="${1#v}"
 tag="v${release}"


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/2382

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->