### PR TITLE
Remove spaces to delight board automation

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -2,7 +2,7 @@ name: Move labelled issues to correct projects
 
 on:
   issues:
-    types: [ labeled ]
+    types: [labeled]
 
 jobs:
   apply_Z-Labs_label:
@@ -100,9 +100,6 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       contains(github.event.issue.labels.*.name, 'A-New-Search-Experience') ||
-      contains(github.event.issue.labels.*.name, 'A-Spaces') ||
-      contains(github.event.issue.labels.*.name, 'A-Space-Settings') ||
-      contains(github.event.issue.labels.*.name, 'A-Subspaces') ||
       contains(github.event.issue.labels.*.name, 'Team: Delight') ||
       contains(github.event.issue.labels.*.name, 'Z-IA') ||
       contains(github.event.issue.labels.*.name, 'Z-NewUserJourney')

--- a/.github/workflows/triage-priority-bugs.yml
+++ b/.github/workflows/triage-priority-bugs.yml
@@ -2,7 +2,7 @@ name: Move P1 bugs to boards
 
 on:
   issues:
-    types: [ labeled, unlabeled ]
+    types: [labeled, unlabeled]
 
 jobs:
   p1_issues_to_team_workboard:
@@ -12,10 +12,7 @@ jobs:
        !contains(github.event.issue.labels.*.name, 'A-E2EE-Cross-Signing') &&
        !contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') &&
        !contains(github.event.issue.labels.*.name, 'A-E2EE-Key-Backup') &&
-       !contains(github.event.issue.labels.*.name, 'A-E2EE-SAS-Verification') &&
-       !contains(github.event.issue.labels.*.name, 'A-Spaces') &&
-       !contains(github.event.issue.labels.*.name, 'A-Spaces-Settings') &&
-       !contains(github.event.issue.labels.*.name, 'A-Subspaces')) &&
+       !contains(github.event.issue.labels.*.name, 'A-E2EE-SAS-Verification')) &&
       (contains(github.event.issue.labels.*.name, 'T-Defect') &&
        contains(github.event.issue.labels.*.name, 'S-Critical') &&
        (contains(github.event.issue.labels.*.name, 'O-Frequent') ||


### PR DESCRIPTION
The spaces responsibilities have shifted and is not looked after by the Delight team anymore.

Spaces issues will not be added to the Delight board anymore, and spaces issues will now show up in the P1 column of the app team

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->