### PR TITLE
Patch Jitsi logs into rageshakes

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -23,7 +23,6 @@ import {
 } from "matrix-widget-api";
 import { ElementWidgetActions } from "matrix-react-sdk/src/stores/widgets/ElementWidgetActions";
 import { logger } from "matrix-js-sdk/src/logger";
-import { log as logToRageshake } from "matrix-react-sdk/src/rageshake/rageshake";
 import { IConfigOptions } from "matrix-react-sdk/src/IConfigOptions";
 import { SnakedObject } from "matrix-react-sdk/src/utils/SnakedObject";
 

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -439,5 +439,7 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
     });
 
     // Patch logs into rageshakes
-    meetApi.on("log", ({ logLevel, args }) => parent?.mx_rage_logger?.log(logLevel, ...args));
+    meetApi.on("log", ({ logLevel, args }) =>
+        (parent as unknown as typeof global).mx_rage_logger?.log(logLevel, ...args),
+    );
 }


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-react-sdk/pull/8643

**:warning: Reviewer: If no further changes are requested, please merge this and https://github.com/matrix-org/matrix-react-sdk/pull/8643 in the morning on my behalf so that we can have Jitsi logs included in any rageshakes coming out of this week's community testing session.** SonarCloud isn't happy with me using a fork, so I have no idea if automerge will work.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->