### PR TITLE
Show a dialog when Jitsi encounters an error

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -300,12 +300,12 @@ function createJWTToken() {
     );
 }
 
-async function notifyHangup() {
+async function notifyHangup(errorMessage?: string) {
     if (widgetApi) {
         // We send the hangup event before setAlwaysOnScreen, because the latter
         // can cause the receiving side to instantly stop listening.
         try {
-            await widgetApi.transport.send(ElementWidgetActions.HangupCall, {});
+            await widgetApi.transport.send(ElementWidgetActions.HangupCall, { errorMessage });
         } finally {
             await widgetApi.setAlwaysOnScreen(false);
         }
@@ -414,7 +414,7 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
         if (error.isFatal) {
             // We got disconnected. Since Jitsi Meet might send us back to the
             // prejoin screen, we're forced to act as if we hung up entirely.
-            notifyHangup();
+            notifyHangup(error.message);
             meetApi = null;
             closeConference();
         }


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-react-sdk/pull/8701

Notes: none
(notes handled in the react-sdk PR)

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->