### PR TITLE
Work around a Jitsi log handling crash

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -366,8 +366,12 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
             startAudioOnly,
             startWithAudioMuted: audioDevice == null,
             startWithVideoMuted: videoDevice == null,
-            // Request all log levels for inclusion in rageshakes
-            apiLogLevels: ["warn", "log", "error", "info", "debug"],
+            // Request some log levels for inclusion in rageshakes
+            // Ideally we would capture all possible log levels, but this can
+            // cause Jitsi Meet to try to post various circular data structures
+            // back over the iframe API, and therefore end up crashing
+            // https://github.com/jitsi/jitsi-meet/issues/11585
+            apiLogLevels: ["warn", "error"],
         } as any,
         jwt: jwt,
     };


### PR DESCRIPTION
Notes: none
(no notes because this was regressed by https://github.com/vector-im/element-web/pull/22270, which is not yet in a release)

Closes https://github.com/vector-im/element-web/issues/22285

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->