### PR TITLE
Show current avatar and name for users in message history

### DIFF
--- a/docs/labs.md
+++ b/docs/labs.md
@@ -146,12 +146,6 @@ If no right panel state is known for the room or it was closed on the last room
 visit, it will default to the room member list. Otherwise, the saved card last
 used in that room is shown.
 
-## Show current profile of users on historical messages (`feature_use_only_current_profiles`)
-
-An experimental flag to determine how the app would behave if a user's current display
-name and avatar (profile) were shown on historical messages instead of the profile details
-at the time when the message was sent.
-
 When enabled, historical messages will use the current profile for the sender.
 
 ## Pin drop location sharing (`feature_location_share_pin_drop`) [In Development]


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-react-sdk/pull/8764

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->