### PR TITLE
Work around a Jitsi bug with display name encoding

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -394,6 +394,16 @@ function joinConference(audioDevice?: string, videoDevice?: string) {
     // fires once when user joins the conference
     // (regardless of video on or off)
     meetApi.on("videoConferenceJoined", () => {
+        // Although we set our displayName with the userInfo option above, that
+        // option has a bug where it causes the name to be the HTML encoding of
+        // what was actually intended. So, we use the displayName command to at
+        // least ensure that the name is correct after entering the meeting.
+        // https://github.com/jitsi/jitsi-meet/issues/11664
+        // We can't just use these commands immediately after creating the
+        // iframe, because there's *another* bug where they can crash Jitsi by
+        // racing with its startup process.
+        if (displayName) meetApi.executeCommand("displayName", displayName);
+        // This doesn't have a userInfo equivalent, so has to be set via commands
         if (avatarUrl) meetApi.executeCommand("avatarUrl", avatarUrl);
 
         if (widgetApi) {


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22521

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Work around a Jitsi bug with display name encoding ([\#22525](https://github.com/vector-im/element-web/pull/22525)). Fixes #22521.<!-- CHANGELOG_PREVIEW_END -->