### PR TITLE
Reduce video rooms log spam

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -98,8 +98,8 @@ const ack = (ev: CustomEvent<IWidgetApiRequest>) => widgetApi.transport.reply(ev
                 new Promise<void>(resolve => {
                     widgetApi.once(`action:${ElementWidgetActions.ClientReady}`, ev => {
                         ev.preventDefault();
-                        widgetApi.transport.reply(ev.detail, {});
                         resolve();
+                        widgetApi.transport.reply(ev.detail, {});
                     });
                 }),
                 new Promise<void>(resolve => {
@@ -145,6 +145,7 @@ const ack = (ev: CustomEvent<IWidgetApiRequest>) => widgetApi.transport.reply(ev
 
             widgetApi.on(`action:${ElementWidgetActions.JoinCall}`,
                 (ev: CustomEvent<IWidgetApiRequest>) => {
+                    ev.preventDefault();
                     const { audioDevice, videoDevice } = ev.detail.data;
                     joinConference(audioDevice as string | null, videoDevice as string | null);
                     ack(ev);
@@ -152,12 +153,14 @@ const ack = (ev: CustomEvent<IWidgetApiRequest>) => widgetApi.transport.reply(ev
             );
             widgetApi.on(`action:${ElementWidgetActions.HangupCall}`,
                 (ev: CustomEvent<IWidgetApiRequest>) => {
+                    ev.preventDefault();
                     meetApi?.executeCommand('hangup');
                     ack(ev);
                 },
             );
             widgetApi.on(`action:${ElementWidgetActions.ForceHangupCall}`,
                 (ev: CustomEvent<IWidgetApiRequest>) => {
+                    ev.preventDefault();
                     meetApi?.dispose();
                     notifyHangup();
                     meetApi = null;
@@ -167,38 +170,43 @@ const ack = (ev: CustomEvent<IWidgetApiRequest>) => widgetApi.transport.reply(ev
             );
             widgetApi.on(`action:${ElementWidgetActions.MuteAudio}`,
                 async (ev: CustomEvent<IWidgetApiRequest>) => {
-                    ack(ev);
+                    ev.preventDefault();
                     if (meetApi && !await meetApi.isAudioMuted()) {
                         meetApi.executeCommand('toggleAudio');
                     }
+                    ack(ev);
                 },
             );
             widgetApi.on(`action:${ElementWidgetActions.UnmuteAudio}`,
                 async (ev: CustomEvent<IWidgetApiRequest>) => {
-                    ack(ev);
+                    ev.preventDefault();
                     if (meetApi && await meetApi.isAudioMuted()) {
                         meetApi.executeCommand('toggleAudio');
                     }
+                    ack(ev);
                 },
             );
             widgetApi.on(`action:${ElementWidgetActions.MuteVideo}`,
                 async (ev: CustomEvent<IWidgetApiRequest>) => {
-                    ack(ev);
+                    ev.preventDefault();
                     if (meetApi && !await meetApi.isVideoMuted()) {
                         meetApi.executeCommand('toggleVideo');
                     }
+                    ack(ev);
                 },
             );
             widgetApi.on(`action:${ElementWidgetActions.UnmuteVideo}`,
                 async (ev: CustomEvent<IWidgetApiRequest>) => {
-                    ack(ev);
+                    ev.preventDefault();
                     if (meetApi && await meetApi.isVideoMuted()) {
                         meetApi.executeCommand('toggleVideo');
                     }
+                    ack(ev);
                 },
             );
             widgetApi.on(`action:${ElementWidgetActions.StartLiveStream}`,
                 (ev: CustomEvent<IWidgetApiRequest>) => {
+                    ev.preventDefault();
                     if (meetApi) {
                         meetApi.executeCommand('startRecording', {
                             mode: 'stream',


### PR DESCRIPTION
If you forget to call `preventDefault` in widget action handlers, matrix-widget-api logs a bunch of errors complaining that the action is unsupported/unhandled, even if it isn't.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Reduce video rooms log spam ([\#22665](https://github.com/vector-im/element-web/pull/22665)).<!-- CHANGELOG_PREVIEW_END -->