### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ env:
   # These must be set for fetchdep.sh to get the right branch
   REPOSITORY: ${{ github.repository }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build"

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -6,6 +6,9 @@ on:
     branches: [ develop ]
   repository_dispatch:
     types: [ element-web-notify ]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build & Upload source maps to Sentry"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,8 +3,13 @@ on:
   pull_request_target:
     types: [ opened, edited, labeled, unlabeled, synchronize ]
 concurrency: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+permissions:
+  contents: read
+
 jobs:
   action:
+    permissions:
+      contents: none
     uses: matrix-org/matrix-js-sdk/.github/workflows/pull_request.yaml@develop
     with:
       labels: "T-Defect,T-Enhancement,T-Task"

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -7,8 +7,13 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   sonarqube:
+    permissions:
+      contents: none
     name: 🩻 SonarQube
     uses: matrix-org/matrix-js-sdk/.github/workflows/sonarcloud.yml@develop
     secrets:

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -9,6 +9,9 @@ env:
   # These must be set for fetchdep.sh to get the right branch
   REPOSITORY: ${{ github.repository }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
+permissions:
+  contents: read
+
 jobs:
   ts_lint:
     name: "Typescript Syntax Check"
@@ -27,6 +30,8 @@ jobs:
         run: "yarn run lint:types"
 
   i18n_lint:
+    permissions:
+      contents: none
     name: "i18n Check"
     uses: matrix-org/matrix-react-sdk/.github/workflows/i18n_check.yml@develop
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,9 @@ env:
   # These must be set for fetchdep.sh to get the right branch
   REPOSITORY: ${{ github.repository }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
+permissions:
+  contents: read
+
 jobs:
   jest:
     name: Jest

--- a/.github/workflows/upgrade_dependencies.yml
+++ b/.github/workflows/upgrade_dependencies.yml
@@ -1,8 +1,13 @@
 name: Upgrade Dependencies
 on:
   workflow_dispatch: { }
+permissions:
+  contents: read
+
 jobs:
   upgrade:
+    permissions:
+      contents: none
     uses: matrix-org/matrix-js-sdk/.github/workflows/upgrade_dependencies.yml@develop
     secrets:
       ELEMENT_BOT_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->