### PR TITLE
Remove the ability to hide yourself in video rooms

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -413,6 +413,9 @@ function joinConference(audioDevice?: string | null, videoDevice?: string | null
         ];
         // Hide all top bar elements
         options.configOverwrite.conferenceInfo = { autoHide: [] };
+        // Remove the ability to hide your own tile, since we're hiding the
+        // settings button which would be the only way to get it back
+        options.configOverwrite.disableSelfViewSettings = true;
     }
 
     meetApi = new JitsiMeetExternalAPI(jitsiDomain, options);


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/issues/22805

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove the ability to hide yourself in video rooms ([\#22806](https://github.com/vector-im/element-web/pull/22806)). Fixes #22805.<!-- CHANGELOG_PREVIEW_END -->