### PR TITLE
Hide screenshare button in video rooms on Desktop

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -410,14 +410,13 @@ function joinConference(audioDevice?: string | null, videoDevice?: string | null
         // deployments that have it enabled
         options.configOverwrite.prejoinConfig = { enabled: false };
         // Use a simplified set of toolbar buttons
+        options.configOverwrite.toolbarButtons = ["microphone", "camera", "tileview", "hangup"];
         // Note: We can hide the screenshare button in video rooms but not in
         // normal conference calls, since in video rooms we control exactly what
         // set of controls appear, but in normal calls we need to leave that up
         // to the deployment's configuration.
         // https://github.com/vector-im/element-web/issues/4880#issuecomment-940002464
-        options.configOverwrite.toolbarButtons = supportsScreensharing
-            ? ["microphone", "camera", "desktop", "tileview", "hangup"]
-            : ["microphone", "camera", "tileview", "hangup"];
+        if (supportsScreensharing) options.configOverwrite.toolbarButtons.splice(2, 0, "desktop");
         // Hide all top bar elements
         options.configOverwrite.conferenceInfo = { autoHide: [] };
         // Remove the ability to hide your own tile, since we're hiding the

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -324,6 +324,11 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return true;
     }
 
+    public supportsJitsiScreensharing(): boolean {
+        // See https://github.com/vector-im/element-web/issues/4880
+        return false;
+    }
+
     public async getAvailableSpellCheckLanguages(): Promise<string[]> {
         return this.ipc.call('getAvailableSpellCheckLanguages');
     }


### PR DESCRIPTION
As a stopgap solution for https://github.com/vector-im/element-web/issues/4880, we can hide the screensharing button in video rooms if the platform doesn't support it.

Depends on https://github.com/matrix-org/matrix-react-sdk/pull/9045

Notes: none
(notes handled in the react-sdk PR)

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->