### PR TITLE
To consider develop built, block on static analysis & tests

### DIFF
--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -33,6 +33,22 @@ jobs:
           SENTRY_PROJECT: riot-web
 
       - run: mv dist/element-*.tar.gz webapp.tar.gz
+      
+      - name: Wait for static analysis to succeed
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: ${{ github.ref }}
+          running-workflow-name: 'Static Analysis'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+      
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: ${{ github.ref }}
+          running-workflow-name: 'Tests'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This way we don't publish to develop.element.io a broken package

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->