### PR TITLE
Revert "Disable url tooltips whilst they are very broken"

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -237,11 +237,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
     }
 
     public needsUrlTooltips(): boolean {
-        // XXX: This should be `true` but caused too many regressions
-        // Given it was effectively a community contribution, it has been disabled until we can fix it
-        // https://github.com/vector-im/element-web/issues/22970
-        // https://github.com/vector-im/element-web/issues/22953
-        return false;
+        return true;
     }
 
     public async getAppVersion(): Promise<string> {


### PR DESCRIPTION
Reverts vector-im/element-web#22976

Requires https://github.com/matrix-org/matrix-react-sdk/pull/9139