### PR TITLE
Disable docker overwriting `latest` tag for RCs

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -40,6 +40,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+          flavor: |
+            latest=${{ contains(github.ref_name, '-rc.') && 'false' || 'auto' }}
 
       - name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->