### PR TITLE
Fix the lockfile, take 3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8293,7 +8293,7 @@ matrix-mock-request@^2.0.0:
     matrix-encrypt-attachment "^1.0.3"
     matrix-events-sdk "^0.0.1-beta.7"
     matrix-js-sdk "github:matrix-org/matrix-js-sdk#develop"
-    matrix-widget-api "^1.0.0"
+    matrix-widget-api "^1.1.1"
     minimist "^1.2.5"
     opus-recorder "^8.0.3"
     pako "^2.0.3"


### PR DESCRIPTION
Follow-up to https://github.com/vector-im/element-web/pull/23280

`yarn install` was causing the lockfile to be modified because I got this version number wrong.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->