### PR TITLE
element.io defaults for sign in with QR

### DIFF
--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -50,5 +50,10 @@
         "apiHost": "https://posthog.element.io"
     },
     "privacy_policy_url": "https://element.io/cookie-policy",
-    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
+    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
+    "login_with_qr": {
+        "reciprocate": {
+            "enable_showing": true
+        }
+    }
 }

--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -61,5 +61,15 @@
     "element_call": {
         "url": "https://element-call.netlify.app"
     },
-    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
+    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
+    "login_with_qr": {
+        "login": {
+            "enable_showing": true
+        },
+        "reciprocate": {
+            "enable_scanning": true,
+            "enable_showing": true
+        },
+        "fallback_http_transport_server": "https://rendezvous.lab.element.dev"
+    }
 }


### PR DESCRIPTION
Proposed behaviour:

app.element.io
==
- enable showing QR from settings where homeserver supports it
- no fallback server

**Login screens:**

No change to login screens.

**Settings screens:**

If the homeserver doesn't have the support for QR login enabled then settings will look no different from normal:

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/6955675/195880778-b0e4237e-bfed-46ea-8077-7f13f9446bf6.png">

However, if QR login is enabled on the homeserver (support for MSC3882 and MSC3886) then it would look like this:

<img width="964" alt="image" src="https://user-images.githubusercontent.com/6955675/195881119-067b7ca0-a02d-4809-94fd-3225e2d627a3.png">

develop.element.io
==

- enable showing QR at point of login
- enable showing and scanning QR from settings where homeserver supports it
- fallback server configured for when HS doesn't have MSC3886 enabled

**Login screens:**

So, at login a new button is visible:

<img width="736" alt="image" src="https://user-images.githubusercontent.com/6955675/195881461-dc9eb002-a060-4a1c-a13f-dd5e255b2eb4.png">

**Settings screens:**

If the homeserver doesn't support MSC3882 then it will look like normal:

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/6955675/195880778-b0e4237e-bfed-46ea-8077-7f13f9446bf6.png">

If the homesever does support MSC3882 then it will look like this:

<img width="936" alt="image" src="https://user-images.githubusercontent.com/6955675/195882287-38056983-6421-4867-bf0d-b14bec3beb9f.png">


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * element.io defaults for sign in with QR ([\#23491](https://github.com/vector-im/element-web/pull/23491)). Contributed by @hughns.<!-- CHANGELOG_PREVIEW_END -->