### PR TITLE
Fix config.json failing to load for Jitsi wrapper in non-root deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@testing-library/react": "^12.1.5",
     "@types/flux": "^3.1.9",
     "@types/jest": "^29.0.0",
+    "@types/jsrsasign": "^10.5.4",
     "@types/modernizr": "^3.5.3",
     "@types/node": "^14.18.28",
     "@types/react": "^17.0.49",

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -65,7 +65,7 @@ const setupCompleted = (async () => {
     try {
         // Queue a config.json lookup asap, so we can use it later on. We want this to be concurrent with
         // other setup work and therefore do not block.
-        const configPromise = getVectorConfig('..');
+        const configPromise = getVectorConfig();
 
         // The widget's options are encoded into the fragment to avoid leaking info to the server.
         const widgetQuery = new URLSearchParams(window.location.hash.substring(1));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,6 +2058,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/jsrsasign@^10.5.4":
+  version "10.5.4"
+  resolved "https://registry.yarnpkg.com/@types/jsrsasign/-/jsrsasign-10.5.4.tgz#e8a147c70e017198fd161600e24c938af7b5ae2f"
+  integrity sha512-05S2f4lGaWgCwFHsa3OEirc4VJf/sJRfhofzxUbuFbmm6NbffPXZrnJqquQAtS3g4C8Z0L9NHgW0znmtDxNoTQ==
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -8314,6 +8319,7 @@ matrix-events-sdk@^0.0.1-beta.7:
   dependencies:
     "@babel/runtime" "^7.12.5"
     another-json "^0.2.0"
+    browser-request "^0.3.3"
     bs58 "^5.0.0"
     content-type "^1.0.4"
     loglevel "^1.7.1"
@@ -8344,6 +8350,7 @@ matrix-mock-request@^2.5.0:
     "@types/ua-parser-js" "^0.7.36"
     await-lock "^2.1.0"
     blurhash "^1.1.3"
+    browser-request "^0.3.3"
     cheerio "^1.0.0-rc.9"
     classnames "^2.2.6"
     commonmark "^0.29.3"


### PR DESCRIPTION
And add missing @types/jsrsasign dependency

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix config.json failing to load for Jitsi wrapper in non-root deployment ([\#23577](https://github.com/vector-im/element-web/pull/23577)).<!-- CHANGELOG_PREVIEW_END -->