### PR TITLE
Run dockerhub builder stage without emulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM node:16-buster as builder
+FROM --platform=$BUILDPLATFORM node:16-buster as builder
 
 # Support custom branches of the react-sdk and js-sdk. This also helps us build
 # images of element-web develop.


### PR DESCRIPTION
Should dramatically improve dockerhub build times
BuildKit will de-dup the webpack build between the arches as well as never doing a webpack build in arm where the terser takes an hour.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->