### PR TITLE
Change label in automation to for the rich text editor

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -18,7 +18,7 @@ jobs:
       contains(github.event.issue.labels.*.name, 'A-Tags') ||
       contains(github.event.issue.labels.*.name, 'A-Video-Rooms') ||
       contains(github.event.issue.labels.*.name, 'A-Message-Starring') ||
-      contains(github.event.issue.labels.*.name, 'A-Composer-WYSIWYG')
+      contains(github.event.issue.labels.*.name, 'A-Rich-Text-Editor')
     steps:
       - uses: actions/github-script@v5
         with:
@@ -296,7 +296,7 @@ jobs:
     name: Add labelled issues to PS features team 3
     runs-on: ubuntu-latest
     if: >
-      contains(github.event.issue.labels.*.name, 'A-Composer-WYSIWYG')
+      contains(github.event.issue.labels.*.name, 'A-Rich-Text-Editor')
     steps:
       - uses: octokit/graphql-action@v2.x
         id: add_to_project


### PR DESCRIPTION
Changing `A-Composer-WYSIWYG` to `A-Rich-Text-Editor`. There were two labels in play on some repos and the latter reflects more accurately our ongoing naming for the feature.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->