### PR TITLE
Add issue automation to tidy Help Wanted

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -30,6 +30,23 @@ jobs:
               labels: ['Z-Labs']
             })
 
+  apply_Help-Wanted_label:
+    name: Add "Help Wanted" label to all "good first issue" and Hacktoberfest
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.issue.labels.*.name, 'good first issue') ||
+      contains(github.event.issue.labels.*.name, 'Hacktoberfest')
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Help Wanted']
+            })
+
   move_needs_info_issues:
     name: X-Needs-Info issues to Need info column on triage board
     runs-on: ubuntu-latest


### PR DESCRIPTION
All "good first issue" and "Hacktoberfest" qualify as "Help Wanted" so the label should be added automatically

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->