### PR TITLE
Don't hardcode /bin/bash in scripts

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script to perform a release of element-web.
 

--- a/scripts/ci_package.sh
+++ b/scripts/ci_package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Runs package.sh, passing DIST_VERSION determined by git
 

--- a/scripts/docker-link-repos.sh
+++ b/scripts/docker-link-repos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/scripts/docker-package.sh
+++ b/scripts/docker-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/scripts/fetch-develop.deps.sh
+++ b/scripts/fetch-develop.deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Fetches the js-sdk and matrix-react-sdk dependencies for development
 # or testing purposes

--- a/scripts/get-version-from-git.sh
+++ b/scripts/get-version-from-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Echoes a version based on the git hashes of the element-web, react-sdk & js-sdk checkouts, for the case where
 # these dependencies are git checkouts.

--- a/scripts/layered.sh
+++ b/scripts/layered.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/scripts/make-icons.sh
+++ b/scripts/make-icons.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Converts an svg logo into the various image resources required by
 # the various platforms deployments.

--- a/scripts/normalize-version.sh
+++ b/scripts/normalize-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Some operating systems, such as NixOS, don't place binaries in `/bin`. The appropriate cross-platform method is to use `/usr/bin/env`.

Notes: Make build scripts work on NixOS

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make build scripts work on NixOS ([\#23740](https://github.com/vector-im/element-web/pull/23740)).<!-- CHANGELOG_PREVIEW_END -->