### PR TITLE
Downgrade to style-loader 2 to regain Webpack 4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
         "semver": "^7.3.7",
         "simple-proxy-agent": "^1.1.0",
         "string-replace-loader": "3",
-        "style-loader": "3",
+        "style-loader": "2",
         "stylelint": "^14.9.1",
         "stylelint-config-prettier": "^9.0.4",
         "stylelint-config-standard": "^29.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11498,10 +11498,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-style-loader@3:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
-  integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
+style-loader@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-2.0.0.tgz#9669602fd4690740eaaec137799a03addbbc393c"
+  integrity sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 style-search@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This is a reintroduction of https://github.com/vector-im/element-web/pull/23894 since https://github.com/vector-im/element-web/pull/24027 regressed it. style-loader 3 isn't compatible with Webpack 4, and causes build errors:

```
2023-01-03 20:29:40.725 [element-js] ERROR in ../matrix-react-sdk/res/themes/light/css/light.pcss
2023-01-03 20:29:40.725 [element-js] Module build failed (from ./node_modules/style-loader/dist/cjs.js):
2023-01-03 20:29:40.725 [element-js] TypeError: this.getOptions is not a function
2023-01-03 20:29:40.725 [element-js]     at Object.loader (/home/robin/code/element-web/element-web/node_modules/style-loader/dist/index.js:19:24)
```

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->