### PR TITLE
Explicitly set worker-loader's publicPath to webapp

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -236,6 +236,15 @@ module.exports = (env, argv) => {
                 {
                     test: /\.worker\.ts$/,
                     loader: "worker-loader",
+                    options: {
+                        // worker-loader v3 defaults to output.publicPath here,
+                        // which causes worker.js to be included in the bundle
+                        // in R2. This in turn causes CSP to fail when loading
+                        // the worker.
+                        // So, we explicitly ask to include it in the webapp
+                        // dir.
+                        publicPath: "webapp",
+                    },
                 },
                 {
                     test: /\.(ts|js)x?$/,


### PR DESCRIPTION
In an attempt to fix the CSP problem caused by upgrading to worker-loader v3, explicitly set worker-loader's publicPath to "webapp" so the change in default does not cause problems on upgrade.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->