### PR TITLE
Upgrade worker loader to v3 (with config fix to prevent bundling)

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.11.2",
-        "worker-loader": "^2.0.0",
+        "worker-loader": "^3.0.0",
         "worklet-loader": "^2.0.0",
         "yaml": "^2.0.1"
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -236,6 +236,11 @@ module.exports = (env, argv) => {
                 {
                     test: /\.worker\.ts$/,
                     loader: "worker-loader",
+                    options: {
+                        // Prevent bundling workers since CSP forbids loading them
+                        // from another origin.
+                        filename: "[hash].worker.js",
+                    },
                 },
                 {
                     test: /\.(ts|js)x?$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12695,13 +12695,13 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-worker-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
-  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+worker-loader@^3.0.0:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-3.0.8.tgz#5fc5cda4a3d3163d9c274a4e3a811ce8b60dbb37"
+  integrity sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==
   dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.0"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 worklet-loader@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/24157

See the issue for evidence that this fix works (hopefully).

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->