### PR TITLE
Pass current language into Jitsi (#24609

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -315,6 +315,31 @@ function closeConference(): void {
     }
 }
 
+// Converts from IETF language tags used by Element (en-US) to the format used
+// by Jitsi (enUS)
+function normalizeLanguage(language: string): string {
+    const [lang, variant] = language.replace("_", "-").split("-");
+
+    if (!variant || lang === variant) {
+        return lang;
+    }
+
+    return lang + variant.toUpperCase();
+}
+
+function mapLanguage(language: string): string {
+    // Element and Jitsi don't agree how to interpret en, so we go with Elements
+    // interpretation to stay consistent
+    switch (language) {
+        case "en":
+            return "enGB";
+        case "enUS":
+            return "en";
+        default:
+            return language;
+    }
+}
+
 // event handler bound in HTML
 // An audio input of undefined instructs Jitsi to start unmuted with whatever
 // audio input it can find, while an input of null instructs it to start muted,
@@ -373,7 +398,7 @@ function joinConference(audioInput?: string | null, videoInput?: string | null):
             apiLogLevels: ["warn", "error"],
         } as any,
         jwt: jwt,
-        lang: language,
+        lang: mapLanguage(normalizeLanguage(language)),
     };
 
     // Video channel widgets need some more tailored config options

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -57,6 +57,7 @@ let roomName: string;
 let startAudioOnly: boolean;
 let isVideoChannel: boolean;
 let supportsScreensharing: boolean;
+let language: string;
 
 let widgetApi: WidgetApi;
 let meetApi: any; // JitsiMeetExternalAPI
@@ -86,6 +87,7 @@ const setupCompleted = (async (): Promise<string | void> => {
         const parentUrl = qsParam("parentUrl", true);
         const widgetId = qsParam("widgetId", true);
         const theme = qsParam("theme", true);
+        language = qsParam("language", true) ?? "en";
 
         if (theme) {
             document.body.classList.add(`theme-${theme.replace(" ", "_")}`);
@@ -371,6 +373,7 @@ function joinConference(audioInput?: string | null, videoInput?: string | null):
             apiLogLevels: ["warn", "error"],
         } as any,
         jwt: jwt,
+        lang: language,
     };
 
     // Video channel widgets need some more tailored config options


### PR DESCRIPTION
Jitsi itself now uses the current language of the user. However, this does not yet apply to the welcome page of the Jitsi widget that says "Join conference", which is only hard-coded to english for now.

This pulls out some changes from https://github.com/vector-im/element-web/pull/23412 which seems to be unlikely to be merged soon.

Signed-off-by: Oliver Sand <oliver.sand@nordeck.net>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->

Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Pass current language into Jitsi ([\#24609](https://github.com/vector-im/element-web/pull/24609)). Contributed by @Fox32.<!-- CHANGELOG_PREVIEW_END -->