### PR TITLE
Remove experimental PWA support for Firefox and Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Element has several tiers of support for different environments:
         that are actively supported by the OS vendor and receive security updates
 -   Experimental
     -   Definition: Issues **accepted**, regressions **do not block** the release
-    -   Element as an installed PWA via current stable version of Chrome, Firefox, and Safari
+    -   Element as an installed PWA via current stable version of Chrome
     -   Mobile web for current stable version of Chrome, Firefox, and Safari on Android, iOS, and iPadOS
 -   Not supported
     -   Definition: Issues only affecting unsupported environments are **closed**


### PR DESCRIPTION
Firefox dropped support for this quite a while back and Safari only supports it on iOS which is not a supported OS for this project.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Remove experimental PWA support for Firefox and Safari ([\#24630](https://github.com/vector-im/element-web/pull/24630)).<!-- CHANGELOG_PREVIEW_END -->