### PR TITLE
Remove deprecated stylelint rules which are handled by prettier

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
     ...require("matrix-react-sdk/.stylelintrc.js"),
-    extends: ["stylelint-config-standard", "stylelint-config-prettier"],
+    extends: ["stylelint-config-standard"],
 };

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
         "string-replace-loader": "3",
         "style-loader": "2",
         "stylelint": "^15.0.0",
-        "stylelint-config-prettier": "^9.0.4",
         "stylelint-config-standard": "^30.0.0",
         "stylelint-scss": "^4.2.0",
         "terser-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-react-sdk/pull/10325

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->