### PR TITLE
Pin versions of third-party github actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
               )
             )
         steps:
-            - uses: tibdex/backport@v2
+            - uses: tibdex/backport@2e217641d82d02ba0603f46b1aeedefb258890ac # v2
               with:
                   labels_template: "<%= JSON.stringify([...labels, 'X-Release-Blocker']) %>"
                   # We can't use GITHUB_TOKEN here or CI won't run on the new PR

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -18,22 +18,22 @@ jobs:
                   fetch-depth: 0 # needed for docker-package to be able to calculate the version
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v2
+              uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2
               with:
                   install: true
 
             - name: Login to Docker Hub
-              uses: docker/login-action@v2
+              uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Docker meta
               id: meta
-              uses: docker/metadata-action@v4
+              uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4
               with:
                   images: |
                       vectorim/element-web
@@ -44,7 +44,7 @@ jobs:
                       latest=${{ contains(github.ref_name, '-rc.') && 'false' || 'auto' }}
 
             - name: Build and push
-              uses: docker/build-push-action@v4
+              uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
               with:
                   context: .
                   push: true
@@ -53,7 +53,7 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
 
             - name: Update repo description
-              uses: peter-evans/dockerhub-description@v3
+              uses: peter-evans/dockerhub-description@202973a37c8a723405c0c5f0a71b6d99db470dae # v3
               continue-on-error: true
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -41,13 +41,13 @@ jobs:
 
             - name: Get diff lines
               id: diff
-              uses: Equip-Collaboration/diff-line-numbers@v1.0.0
+              uses: Equip-Collaboration/diff-line-numbers@df70b4b83e05105c15f20dc6cc61f1463411b2a6 # v1.0.0
               with:
                   include: '["\\.tsx?$"]'
 
             - name: Detecting files changed
               id: files
-              uses: futuratrepadeira/changed-files@v4.0.0
+              uses: futuratrepadeira/changed-files@96d5fd702a6479d573287ef07381ad59acc390ed # v4.0.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   pattern: '^.*\.tsx?$'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
 
             - name: Get number of CPU cores
               id: cpu-cores
-              uses: SimenB/github-actions-cpu-cores@v1
+              uses: SimenB/github-actions-cpu-cores@410541432439795d30db6501fb1d8178eb41e502 # v1
 
             - name: Run tests with coverage
               run: "yarn coverage --ci --reporters github-actions --max-workers ${{ steps.cpu-cores.outputs.count }}"


### PR DESCRIPTION
Type: Task
Related: https://github.com/matrix-org/matrix-js-sdk/pull/3208
Related: https://github.com/matrix-org/matrix-react-sdk/pull/10351
Related: https://github.com/vector-im/element-web/pull/24786

Previously, we used tags to version third-party actions. t3chguy suggested we should pin them to specific commit hashes by default.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->