### PR TITLE
Add API params to mute audio and/or video in Jitsi calls by default

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -55,6 +55,8 @@ let roomId: string;
 let openIdToken: IOpenIDCredentials;
 let roomName: string;
 let startAudioOnly: boolean;
+let startWithAudioMuted: boolean | undefined;
+let startWithVideoMuted: boolean | undefined;
 let isVideoChannel: boolean;
 let supportsScreensharing: boolean;
 let language: string;
@@ -79,6 +81,13 @@ const setupCompleted = (async (): Promise<string | void> => {
                 throw new Error(`Expected singular ${name} in query string`);
             }
             return vals[0];
+        };
+        const parseBooleanOrUndefined = (value: string | undefined): boolean | undefined => {
+            if (value === undefined) {
+                return undefined;
+            }
+
+            return value === "true";
         };
 
         // If we have these params, expect a widget API to be available (ie. to be in an iframe
@@ -197,6 +206,8 @@ const setupCompleted = (async (): Promise<string | void> => {
         roomId = qsParam("roomId", true);
         roomName = qsParam("roomName", true);
         startAudioOnly = qsParam("isAudioOnly", true) === "true";
+        startWithAudioMuted = parseBooleanOrUndefined(qsParam("isStartWithAudioMuted", true));
+        startWithVideoMuted = parseBooleanOrUndefined(qsParam("isStartWithVideoMuted", true));
         isVideoChannel = qsParam("isVideoChannel", true) === "true";
         supportsScreensharing = qsParam("supportsScreensharing", true) === "true";
 
@@ -388,8 +399,8 @@ function joinConference(audioInput?: string | null, videoInput?: string | null):
         configOverwrite: {
             subject: roomName,
             startAudioOnly,
-            startWithAudioMuted: audioInput === null,
-            startWithVideoMuted: videoInput === null,
+            startWithAudioMuted: audioInput === null ? true : startWithAudioMuted,
+            startWithVideoMuted: videoInput === null ? true : startWithVideoMuted,
             // Request some log levels for inclusion in rageshakes
             // Ideally we would capture all possible log levels, but this can
             // cause Jitsi Meet to try to post various circular data structures

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -206,8 +206,8 @@ const setupCompleted = (async (): Promise<string | void> => {
         roomId = qsParam("roomId", true);
         roomName = qsParam("roomName", true);
         startAudioOnly = qsParam("isAudioOnly", true) === "true";
-        startWithAudioMuted = parseBooleanOrUndefined(qsParam("isStartWithAudioMuted", true));
-        startWithVideoMuted = parseBooleanOrUndefined(qsParam("isStartWithVideoMuted", true));
+        startWithAudioMuted = parseBooleanOrUndefined(qsParam("startWithAudioMuted", true));
+        startWithVideoMuted = parseBooleanOrUndefined(qsParam("startWithVideoMuted", true));
         isVideoChannel = qsParam("isVideoChannel", true) === "true";
         supportsScreensharing = qsParam("supportsScreensharing", true) === "true";
 


### PR DESCRIPTION
Should be merged together with https://github.com/matrix-org/matrix-react-sdk/pull/10376

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

We have the use case that we don't want to activate the video and/or audio of Jitsi participants by default. There is the `isAudioOnly` flag, but that has some side effects, like that a joining user must activate their camera before being able to see others who have their camera activated (hence "audio only").

This PR proposes to add flags for both the [`startWithAudioMuted`](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-configuration/#startwithaudiomuted) and [`startWithVideoMuted`](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-configuration/#startwithvideomuted) configs. These settings can be set when adding the jitsi widget to a room (we do that with a bot for example).

Requires the following PR in the matrix-react-sdk: 

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->

Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add API params to mute audio and/or video in Jitsi calls by default ([\#24820](https://github.com/vector-im/element-web/pull/24820)). Contributed by @dhenneke.<!-- CHANGELOG_PREVIEW_END -->