### PR TITLE
Update safari support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Element has several tiers of support for different environments:
 
 -   Supported
     -   Definition: Issues **actively triaged**, regressions **block** the release
-    -   Last 2 major versions of Chrome, Firefox, Safari, and Edge on desktop OSes
+    -   Last 2 major versions of Chrome, Firefox, and Edge on desktop OSes
+    -   Last 2 versions of Safari
     -   Latest release of official Element Desktop app on desktop OSes
     -   Desktop OSes means macOS, Windows, and Linux versions for desktop devices
         that are actively supported by the OS vendor and receive security updates


### PR DESCRIPTION
Safari major versions work differently than any other browsers. It is tied to the OS version that is very rarely updated.

Release cadence has changed internally at Apple, and it makes sense now to do support the last 2 versions rather than the last 2 major.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->