### PR TITLE
Update matrix-widget-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "katex": "^0.16.0",
         "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
         "matrix-react-sdk": "github:matrix-org/matrix-react-sdk#develop",
-        "matrix-widget-api": "^1.1.1",
+        "matrix-widget-api": "^1.3.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "sanitize-html": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8172,6 +8172,14 @@ matrix-widget-api@^1.0.0, matrix-widget-api@^1.1.1:
     "@types/events" "^3.0.0"
     events "^3.2.0"
 
+matrix-widget-api@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.3.1.tgz#e38f404c76bb15c113909505c1c1a5b4d781c2f5"
+  integrity sha512-+rN6vGvnXm+fn0uq9r2KWSL/aPtehD6ObC50jYmUcEfgo8CUpf9eUurmjbRlwZkWq3XHXFuKQBUCI9UzqWg37Q==
+  dependencies:
+    "@types/events" "^3.0.0"
+    events "^3.2.0"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/24858 — it's not strictly necessary to update element-web, but for good measure we should keep it up to date with the version used by the react-sdk.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->