### PR TITLE
Enable blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,3 @@
-blank_issues_enabled: false
 contact_links:
     - name: Questions & support
       url: https://matrix.to/#/#element-web:matrix.org


### PR DESCRIPTION
We currently have the blank template disabled. This is limiting though as there are cases where an issue can't reasonably follow one of the other templates. As an example, many of the issues we _create_ to work on in the web app team cannot sensibly follow the template.

There was possibly a problem with spam or low quality reports in the past that has led to the blank template being disabled. Since the option appears to show at caption size at the very bottom of the list, I don't expect this to be a large problem though.

![image](https://user-images.githubusercontent.com/1137962/226954019-19d3380e-409e-445b-98dc-31b43ee42044.png)


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->