### PR TITLE
remove makeType utility from loading-test

### DIFF
--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -25,7 +25,6 @@ import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
 import MatrixChat from "matrix-react-sdk/src/components/structures/MatrixChat";
 import dis from "matrix-react-sdk/src/dispatcher/dispatcher";
 import MockHttpBackend from "matrix-mock-request";
-import { makeType } from "matrix-react-sdk/src/utils/TypeUtils";
 import { ValidatedServerConfig } from "matrix-react-sdk/src/utils/ValidatedServerConfig";
 import { IndexedDBCryptoStore } from "matrix-js-sdk/src/crypto/store/indexeddb-crypto-store";
 import { QueryDict, sleep } from "matrix-js-sdk/src/utils";
@@ -117,12 +116,12 @@ describe("loading:", function () {
             {
                 default_hs_url: DEFAULT_HS_URL,
                 default_is_url: DEFAULT_IS_URL,
-                validated_server_config: makeType(ValidatedServerConfig, {
+                validated_server_config: {
                     hsUrl: DEFAULT_HS_URL,
                     hsName: "TEST_ENVIRONMENT",
                     hsNameIsDifferent: false, // yes, we lie
                     isUrl: DEFAULT_IS_URL,
-                }),
+                } as ValidatedServerConfig,
                 embeddedPages: {
                     homeUrl: "data:text/html;charset=utf-8;base64,PGh0bWw+PC9odG1sPg==",
                 },


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

`makeType` utility is not necessary, will be removed while cleaning up utils in https://github.com/matrix-org/matrix-react-sdk/pull/10455

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->
