### PR TITLE
Add gstatic.cn to CSP script-src in index.html

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -26,7 +26,7 @@
     <meta http-equiv="Content-Security-Policy" content="
         default-src 'none';
         style-src 'self' 'unsafe-inline' <%= csp_extra_source %>;
-        script-src 'self' 'unsafe-eval' https://www.recaptcha.net https://www.gstatic.com <%= csp_extra_source %>;
+        script-src 'self' 'unsafe-eval' https://www.recaptcha.net https://www.gstatic.com https://www.gstatic.cn <%= csp_extra_source %>;
         img-src * blob: data:;
         connect-src *;
         font-src 'self' data: <%= csp_extra_source %>;


### PR DESCRIPTION
ReCaptcha sent the request to www.gstatic.cn instead of www.gstatic.com when the user was in China, which caused the request to be blocked by the Content Security Policy (CSP).