### PR TITLE
Update the loading-test.tsx to not force unwrap selectors

### DIFF
--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -630,9 +630,18 @@ describe("loading:", function () {
                 device_id: "DEVICE_ID",
                 access_token: "access_token",
             });
-        fireEvent.change(matrixChat.container.querySelector("#mx_LoginForm_username")!, { target: { value: "user" } });
-        fireEvent.change(matrixChat.container.querySelector("#mx_LoginForm_password")!, { target: { value: "pass" } });
-        fireEvent.click(screen.getByText("Sign in", { selector: ".mx_Login_submit" }));
+        const username = matrixChat.container.querySelector("#mx_LoginForm_username");
+        if (username) {
+            fireEvent.change(username, { target: { value: "user" } });
+        }
+        const password = matrixChat.container.querySelector("#mx_LoginForm_password");
+        if (password) {
+            fireEvent.change(password, { target: { value: "pass" } });
+        }
+        const signin = screen.getByText("Sign in", { selector: ".mx_Login_submit" });
+        if (signin) {
+            fireEvent.click(signin);
+        }
 
         return httpBackend
             .flush()


### PR DESCRIPTION
I’m getting a rough error when trying to submit a pull request to the matrix-js-sdk here: https://github.com/matrix-org/matrix-js-sdk/actions/runs/4610625733/jobs/8149315844

the logs aren’t very helpful, they’re almost exactly the same as a successful run. Here’s a success that I compared it against: https://github.com/matrix-org/matrix-js-sdk/actions/runs/4629038080/jobs/8188824441

At the end of the failed run it spits out errors in this code:
```
2023-04-04T17:34:58.2505947Z     Unable to fire a "change" event - please provide a DOM element.
2023-04-04T17:34:58.2506128Z
2023-04-04T17:34:58.2506285Z       631 |                 access_token: "access_token",
2023-04-04T17:34:58.2506514Z       632 |             });
2023-04-04T17:34:58.2506967Z     > 633 |         fireEvent.change(matrixChat.container.querySelector("#mx_LoginForm_username"), { target: { value: "user" } });
2023-04-04T17:34:58.2507322Z           |                   ^
2023-04-04T17:34:58.2507755Z       634 |         fireEvent.change(matrixChat.container.querySelector("#mx_LoginForm_password"), { target: { value: "pass" } });
2023-04-04T17:34:58.2508249Z       635 |         fireEvent.click(screen.getByText("Sign in", { selector: ".mx_Login_submit" }));
2023-04-04T17:34:58.2508565Z       636 |
```

These errors were not in the successful run and were the only major difference that I could find in the two runs.

I am not convinced this is actually a problem, but it definitely can’t hurt and perhaps clearing this error will uncover the real one.

Thank you

signed-off-by austin ellis austin@hntlabs.com


## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))



Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Update the loading-test.tsx to not force unwrap selectors ([\#25061](https://github.com/vector-im/element-web/pull/25061)). Contributed by @texuf.<!-- CHANGELOG_PREVIEW_END -->