### PR TITLE
Revert "Strip data-testid in production builds" (#25163

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -32,16 +32,4 @@ module.exports = {
         "@babel/plugin-syntax-dynamic-import",
         "@babel/plugin-transform-runtime",
     ],
-    env: {
-        production: {
-            plugins: [
-                [
-                    "babel-plugin-jsx-remove-data-test-id",
-                    {
-                        attributes: "data-testid",
-                    },
-                ],
-            ],
-        },
-    },
 };

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
         "allchange": "^1.0.6",
         "babel-jest": "^29.0.0",
         "babel-loader": "^8.2.2",
-        "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
         "chokidar": "^3.5.1",
         "concurrently": "^8.0.0",
         "cpx": "^1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -269,7 +269,6 @@ module.exports = (env, argv) => {
                     },
                     loader: "babel-loader",
                     options: {
-                        envName: nodeEnv,
                         cacheDirectory: true,
                     },
                 },
@@ -435,9 +434,6 @@ module.exports = (env, argv) => {
                         {
                             // TS -> JS because the worklet-loader won't do this for us.
                             loader: "babel-loader",
-                            options: {
-                                envName: nodeEnv,
-                            },
                         },
                     ],
                 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3005,11 +3005,6 @@ babel-plugin-jest-hoist@^29.5.0:
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-jsx-remove-data-test-id@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jsx-remove-data-test-id/-/babel-plugin-jsx-remove-data-test-id-3.0.0.tgz#15c95f97ce0ff60d72b29e403bde245f86393288"
-  integrity sha512-E4uM/LIUizjy2Z5tVAfa8pSXsYgoKWJ97kzuEMfsIxSLSNDWsAhgFVPkgNuakViX5dkNjw1DKIi0VpWP6djqbw==
-
 babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz#5d1bd3836d0a19e1b84bbf2d9640ccb6f951c122"


### PR DESCRIPTION
Reverts vector-im/element-web#25152
Fixes https://github.com/vector-im/element-web/issues/25161