### PR TITLE
Deprecate `$spacing` variables

### DIFF
--- a/code_style.md
+++ b/code_style.md
@@ -289,7 +289,7 @@ Note: We use PostCSS + some plugins to process our styles. It looks like SCSS, b
     2. `mx_MyFoo_avatar`
     3. `mx_MyFoo_avatarUser`
     4. `mx_MyFoo_avatar--user`
-3. Use the `$font` and `$spacing` variables instead of manual values.
+3. Use the `$font` variables instead of manual values.
 4. Keep indentation/nesting to a minimum. Maximum suggested nesting is 5 layers.
 5. Use the whole class name instead of shortcuts:
 


### PR DESCRIPTION
Per https://github.com/matrix-org/matrix-react-sdk/pull/10686, these don't make much sense at the moment.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->