### PR TITLE
Handle trailing dot FQDNs for domain-specific config.json files

### DIFF
--- a/src/vector/getconfig.ts
+++ b/src/vector/getconfig.ts
@@ -21,7 +21,13 @@ import type { IConfigOptions } from "matrix-react-sdk/src/IConfigOptions";
 export async function getVectorConfig(relativeLocation = ""): Promise<IConfigOptions | undefined> {
     if (relativeLocation !== "" && !relativeLocation.endsWith("/")) relativeLocation += "/";
 
-    const specificConfigPromise = getConfig(`${relativeLocation}config.${window.location.hostname}.json`);
+    // Handle trailing dot FQDNs
+    let domain = window.location.hostname.trimEnd();
+    if (domain[domain.length - 1] === ".") {
+        domain = domain.slice(0, -1);
+    }
+
+    const specificConfigPromise = getConfig(`${relativeLocation}config.${domain}.json`);
     const generalConfigPromise = getConfig(relativeLocation + "config.json");
 
     try {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/8858

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Handle trailing dot FQDNs for domain-specific config.json files ([\#25351](https://github.com/vector-im/element-web/pull/25351)). Fixes #8858.<!-- CHANGELOG_PREVIEW_END -->