### PR TITLE
Remove old ansible comments

### DIFF
--- a/res/welcome.html
+++ b/res/welcome.html
@@ -181,11 +181,6 @@ we don't have an account and should hide them. No account == no guest account ei
                 <div class="mx_ButtonLabel">_t("Create Account")</div>
             </a>
         </div>
-        <!-- The comments below are meant to be used by Ansible as a quick way
-             to strip out the marked content when desired.
-             See https://github.com/vector-im/element-web/issues/8622.
-             TODO: Strip out these comments and rely on the guest flag -->
-        <!-- BEGIN Ansible: Remove these lines when guest access is disabled -->
         <div class="mx_ButtonRow mx_WelcomePage_guestFunctions">
             <div>
                 <a href="#/directory" class="mx_ButtonParent mx_SecondaryButton mx_Button_iconRoomDirectory">
@@ -193,6 +188,5 @@ we don't have an account and should hide them. No account == no guest account ei
                 </a>
             </div>
         </div>
-        <!-- END Ansible: Remove these lines when guest access is disabled -->
     </div>
 </div>


### PR DESCRIPTION
The section is auto-hidden if guest access is disabled
and can also be removed via a custom welcome.html in config.json

Fixes https://github.com/vector-im/element-web/issues/9963
