### PR TITLE
Fix analyse:webpack-bundles script

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "test": "jest",
         "coverage": "yarn test --coverage",
         "analyse:unused-exports": "node ./scripts/analyse_unused_exports.js",
-        "analyse:webpack-bundles": "webpack-bundle-analyzer webpack-stats.json"
+        "analyse:webpack-bundles": "webpack-bundle-analyzer webpack-stats.json webapp"
     },
     "resolutions": {
         "@types/react-dom": "17.0.19",


### PR DESCRIPTION
Without this it can't analyse the bundles only the stats

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->