### PR TITLE
Redirect to the SSO page if `sso_redirect_options.on_welcome_page` is enabled and the URL hash is empty

### DIFF
--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -107,7 +107,7 @@ export async function loadApp(fragParams: {}): Promise<ReactElement> {
     const ssoRedirects = parseSsoRedirectOptions(config);
     let autoRedirect = ssoRedirects.immediate === true;
     // XXX: This path matching is a bit brittle, but better to do it early instead of in the app code.
-    const isWelcomeOrLanding = window.location.hash === "#/welcome" || window.location.hash === "#";
+    const isWelcomeOrLanding = window.location.hash === "#/welcome" || window.location.hash === "#" || window.location.hash === '';
     if (!autoRedirect && ssoRedirects.on_welcome_page && isWelcomeOrLanding) {
         autoRedirect = true;
     }

--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -107,7 +107,8 @@ export async function loadApp(fragParams: {}): Promise<ReactElement> {
     const ssoRedirects = parseSsoRedirectOptions(config);
     let autoRedirect = ssoRedirects.immediate === true;
     // XXX: This path matching is a bit brittle, but better to do it early instead of in the app code.
-    const isWelcomeOrLanding = window.location.hash === "#/welcome" || window.location.hash === "#" || window.location.hash === '';
+    const isWelcomeOrLanding =
+        window.location.hash === "#/welcome" || window.location.hash === "#" || window.location.hash === "";
     if (!autoRedirect && ssoRedirects.on_welcome_page && isWelcomeOrLanding) {
         autoRedirect = true;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

The configuration `{ "sso_redirect_options": { "on_welcome_page": true } }` automatically redirects the user to the SSO login when they open Element for the first time. However, this only works if a user opens the URLs `https://my.element.local/#` or `https://my.element.local/#/welcome`. This PR adds the option to also support `https://my.element.local/` which is a more usual link when the user types in the URL manually or has a link in e.g. a company portal.

I didn't add a test because I'm unsure how to test it properly. Would that be ok? If you would prefer to have a test, I could try to add them to `loading-test.tsx`.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->

Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Redirect to the SSO page if `sso_redirect_options.on_welcome_page` is enabled and the URL hash is empty ([\#25495](https://github.com/vector-im/element-web/pull/25495)). Contributed by @dhenneke.<!-- CHANGELOG_PREVIEW_END -->