### PR TITLE
Remove the ACAO header which is added by default on Cloudflare Pages

### DIFF
--- a/.github/cfp_headers
+++ b/.github/cfp_headers
@@ -1,4 +1,5 @@
 /*
+  ! Access-Control-Allow-Origin
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
Related to https://github.com/vector-im/sre-internal/issues/2606

Cloudflare sets `Access-Control-Allow-Origin: *` by default on pages sites. This removes it from the main develop URL. The main deployment doesn't have it:

```
$ curl -sIL https://app.element.io
HTTP/2 200 
date: Wed, 21 Jun 2023 15:03:53 GMT
content-type: text/html
last-modified: Tue, 20 Jun 2023 09:30:42 GMT
vary: Accept-Encoding
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-frame-options: sameorigin
cache-control: no-cache
permissions-policy: interest-cohort=()
```

However develop is set to the default:
```
$ curl -sIL https://develop.element.io
HTTP/2 200 
date: Wed, 21 Jun 2023 15:04:37 GMT
content-type: text/html; charset=utf-8
access-control-allow-origin: *
```

I'm not sure if we need to set it for any other paths of the app.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->
