### PR TITLE
Revert "Point develop.element.io to our Element Call + LiveKit experiment"

### DIFF
--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -44,7 +44,7 @@
         "feature_video_rooms": true
     },
     "element_call": {
-        "url": "https://element-call-livekit.netlify.app"
+        "url": "https://element-call.netlify.app"
     },
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
 }


### PR DESCRIPTION
Reverts vector-im/element-web#25636
The widget version of livekit element call is cannot be testes. We wait until it is testable in the widget version and than change it back to the livekit url.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->