### PR TITLE
Conform more of the codebase to strictNullChecks & noImplicitAny

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -444,20 +444,20 @@ async function joinConference(audioInput?: string | null, videoInput?: string | 
     if (isVideoChannel) {
         // Ensure that we skip Jitsi Meet's native prejoin screen, for
         // deployments that have it enabled
-        options.configOverwrite.prejoinConfig = { enabled: false };
+        options.configOverwrite!.prejoinConfig = { enabled: false };
         // Use a simplified set of toolbar buttons
-        options.configOverwrite.toolbarButtons = ["microphone", "camera", "tileview", "hangup"];
+        options.configOverwrite!.toolbarButtons = ["microphone", "camera", "tileview", "hangup"];
         // Note: We can hide the screenshare button in video rooms but not in
         // normal conference calls, since in video rooms we control exactly what
         // set of controls appear, but in normal calls we need to leave that up
         // to the deployment's configuration.
         // https://github.com/vector-im/element-web/issues/4880#issuecomment-940002464
-        if (supportsScreensharing) options.configOverwrite.toolbarButtons.splice(2, 0, "desktop");
+        if (supportsScreensharing) options.configOverwrite!.toolbarButtons.splice(2, 0, "desktop");
         // Hide all top bar elements
-        options.configOverwrite.conferenceInfo = { autoHide: [] };
+        options.configOverwrite!.conferenceInfo = { autoHide: [] };
         // Remove the ability to hide your own tile, since we're hiding the
         // settings button which would be the only way to get it back
-        options.configOverwrite.disableSelfViewSettings = true;
+        options.configOverwrite!.disableSelfViewSettings = true;
     }
 
     meetApi = new JitsiMeetExternalAPI(jitsiDomain, options);

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -37,8 +37,31 @@ import type {
     AudioMuteStatusChangedEvent,
     LogEvent,
     VideoMuteStatusChangedEvent,
+    ExternalAPIOptions as _ExternalAPIOptions,
+    Config as _Config,
 } from "jitsi-meet";
 import { getVectorConfig } from "../getconfig";
+
+interface Config extends _Config {
+    // Jitsi's types are missing these fields
+    prejoinConfig?: {
+        enabled: boolean;
+        hideDisplayName?: boolean;
+        hideExtraJoinButtons?: string[];
+    };
+    toolbarButtons?: string[];
+    conferenceInfo?: {
+        alwaysVIsible?: string[];
+        autoHide?: string[];
+    };
+    disableSelfViewSettings?: boolean;
+}
+
+interface ExternalAPIOptions extends _ExternalAPIOptions {
+    // Jitsi's types are missing these fields
+    lang?: string;
+    configOverwrite?: Config;
+}
 
 // We have to trick webpack into loading our CSS for us.
 require("./index.pcss");
@@ -382,7 +405,7 @@ async function joinConference(audioInput?: string | null, videoInput?: string | 
             "our fragment values and not recognizing the options.",
     );
 
-    const options = {
+    const options: ExternalAPIOptions = {
         width: "100%",
         height: "100%",
         parentNode: document.querySelector("#jitsiContainer") ?? undefined,

--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -460,8 +460,8 @@ describe("loading:", function () {
                     httpBackend.verifyNoOutstandingExpectation();
                     expect(matrixChat?.container.querySelector(".mx_Welcome")).toBeTruthy();
                     expect(windowLocation?.hash).toEqual("#/welcome");
-                    expect(MatrixClientPeg.get().baseUrl).toEqual(DEFAULT_HS_URL);
-                    expect(MatrixClientPeg.get().idBaseUrl).toEqual(DEFAULT_IS_URL);
+                    expect(MatrixClientPeg.safeGet().baseUrl).toEqual(DEFAULT_HS_URL);
+                    expect(MatrixClientPeg.safeGet().idBaseUrl).toEqual(DEFAULT_IS_URL);
                 });
         });
 


### PR DESCRIPTION
`MAIN_TOOLBAR_BUTTONS` might want to be `TOOLBAR_BUTTONS` but did not want to introduce functional changes here