### PR TITLE
Allow default_server_config as a fallback config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -45,10 +45,9 @@ One of the following options **must** be supplied:
    information. These are the same values seen as `base_url` in the `default_server_config` example, with `default_is_url`
    being optional.
 
-If a combination of these three methods is used then Element will fail to load. This is because it is unclear which
-should be considered "first". However, if both `default_server_config` and `default_server_name` are used, Element will
-try to look up the connection infomation using `.well-known`, and if that fails, take `default_server_config` as the
-homeserver connection infomation.
+If both `default_server_config` and `default_server_name` are used, Element will try to look up the connection
+infomation using `.well-known`, and if that fails, take `default_server_config` as the homeserver connection
+infomation.
 
 ## Labs flags
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,7 +46,9 @@ One of the following options **must** be supplied:
    being optional.
 
 If a combination of these three methods is used then Element will fail to load. This is because it is unclear which
-should be considered "first".
+should be considered "first". However, if both `default_server_config` and `default_server_name` are used, Element will
+try to look up the connection infomation using `.well-known`, and if that fails, take `default_server_config` as the
+homeserver connection infomation.
 
 ## Labs flags
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1,5 +1,5 @@
 {
-    "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.": "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.",
+    "Invalid configuration: a default_hs_url can't be specified along with default_server_name or default_server_config": "Invalid configuration: a default_hs_url can't be specified along with default_server_name or default_server_config",
     "Invalid configuration: no default server specified.": "Invalid configuration: no default server specified.",
     "Your Element is misconfigured": "Your Element is misconfigured",
     "Your Element configuration contains invalid JSON. Please correct the problem and reload the page.": "Your Element configuration contains invalid JSON. Please correct the problem and reload the page.",

--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -169,6 +169,13 @@ async function verifyServerConfig(): Promise<IConfigOptions> {
         const isUrl = config["default_is_url"];
 
         const incompatibleOptions = [wkConfig, serverName, hsUrl].filter((i) => !!i);
+        if (hsUrl && (wkConfig || serverName)) {
+            // noinspection ExceptionCaughtLocallyJS
+            throw new UserFriendlyError(
+                "Invalid configuration: a default_hs_url can't be specified along with default_server_name " +
+                    "or default_server_config",
+            );
+        }
         if (incompatibleOptions.length < 1) {
             // noinspection ExceptionCaughtLocallyJS
             throw new UserFriendlyError("Invalid configuration: no default server specified.");

--- a/src/vector/mobile_guide/index.ts
+++ b/src/vector/mobile_guide/index.ts
@@ -79,10 +79,10 @@ async function initPage(): Promise<void> {
             }
         } catch (e) {
             if (wkConfig && wkConfig["m.homeserver"]) {
-                hsUrl = wkConfig["m.homeserver"]["base_url"];
+                hsUrl = wkConfig["m.homeserver"]["base_url"] || undefined;
 
                 if (wkConfig["m.identity_server"]) {
-                    isUrl = wkConfig["m.identity_server"]["base_url"];
+                    isUrl = wkConfig["m.identity_server"]["base_url"] || undefined;
                 }
             } else {
                 logger.error(e);

--- a/src/vector/mobile_guide/index.ts
+++ b/src/vector/mobile_guide/index.ts
@@ -44,10 +44,10 @@ async function initPage(): Promise<void> {
     const defaultIsUrl = config?.["default_is_url"];
 
     const incompatibleOptions = [wkConfig, serverName, defaultHsUrl].filter((i) => !!i);
-    if (incompatibleOptions.length > 1) {
+    if (defaultHsUrl && (wkConfig || serverName)) {
         return renderConfigError(
-            "Invalid configuration: can only specify one of default_server_config, default_server_name, " +
-                "or default_hs_url.",
+            "Invalid configuration: a default_hs_url can't be specified along with default_server_name " +
+                "or default_server_config",
         );
     }
     if (incompatibleOptions.length < 1) {
@@ -57,7 +57,7 @@ async function initPage(): Promise<void> {
     let hsUrl: string | undefined;
     let isUrl: string | undefined;
 
-    if (typeof wkConfig?.["m.homeserver"]?.["base_url"] === "string") {
+    if (!serverName && typeof wkConfig?.["m.homeserver"]?.["base_url"] === "string") {
         hsUrl = wkConfig["m.homeserver"]["base_url"];
 
         if (typeof wkConfig["m.identity_server"]?.["base_url"] === "string") {
@@ -78,8 +78,16 @@ async function initPage(): Promise<void> {
                 }
             }
         } catch (e) {
-            logger.error(e);
-            return renderConfigError("Unable to fetch homeserver configuration");
+            if (wkConfig && wkConfig["m.homeserver"]) {
+                hsUrl = wkConfig["m.homeserver"]["base_url"];
+
+                if (wkConfig["m.identity_server"]) {
+                    isUrl = wkConfig["m.identity_server"]["base_url"];
+                }
+            } else {
+                logger.error(e);
+                return renderConfigError("Unable to fetch homeserver configuration");
+            }
         }
     }
 

--- a/test/app-tests/server-config-test.ts
+++ b/test/app-tests/server-config-test.ts
@@ -47,16 +47,16 @@ describe("Loading server config", function () {
                 },
             },
         });
-        await loadApp();
-        expect(SdkConfig.get("validated_server_config").hsUrl).toBe("https://matrix-client.matrix.org");
+        await loadApp({});
+        expect((SdkConfig.get("validated_server_config") || {}).hsUrl).toBe("https://matrix-client.matrix.org");
     });
 
     it("should use the default_server_name when resolveable", async function () {
         SdkConfig.put({
             default_server_name: "matrix.org",
         });
-        await loadApp();
-        expect(SdkConfig.get("validated_server_config").hsUrl).toBe("https://matrix-client.matrix.org");
+        await loadApp({});
+        expect((SdkConfig.get("validated_server_config") || {}).hsUrl).toBe("https://matrix-client.matrix.org");
     });
 
     it(
@@ -72,8 +72,8 @@ describe("Loading server config", function () {
                     },
                 },
             });
-            await loadApp();
-            expect(SdkConfig.get("validated_server_config").hsUrl).toBe("https://matrix-client.matrix.org");
+            await loadApp({});
+            expect((SdkConfig.get("validated_server_config") || {}).hsUrl).toBe("https://matrix-client.matrix.org");
         },
     );
 });

--- a/test/app-tests/server-config-test.ts
+++ b/test/app-tests/server-config-test.ts
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 Yorusaka Miyabi <shadowrz@disroot.org>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import SdkConfig from "matrix-react-sdk/src/SdkConfig";
+import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
+import fetchMock from "fetch-mock-jest";
+
+import { loadApp } from "../../src/vector/app";
+import WebPlatform from "../../src/vector/platform/WebPlatform";
+
+fetchMock.config.overwriteRoutes = true;
+
+describe("Loading server config", function () {
+    beforeEach(async () => {
+        SdkConfig.reset();
+        PlatformPeg.set(new WebPlatform());
+        fetchMock.get("https://matrix-client.matrix.org/_matrix/client/versions", {
+            unstable_features: {},
+            versions: [],
+        });
+        fetchMock.get("https://matrix.org/.well-known/matrix/client", {
+            "m.homeserver": {
+                base_url: "https://matrix-client.matrix.org",
+            },
+        });
+        fetchMock.get("/version", "1.10.13");
+    });
+
+    it("should use the default_server_config", async function () {
+        SdkConfig.put({
+            default_server_config: {
+                "m.homeserver": {
+                    base_url: "https://matrix-client.matrix.org",
+                },
+            },
+        });
+        await loadApp();
+        expect(SdkConfig.get("validated_server_config").hsUrl).toBe("https://matrix-client.matrix.org");
+    });
+
+    it("should use the default_server_name when resolveable", async function () {
+        SdkConfig.put({
+            default_server_name: "matrix.org",
+        });
+        await loadApp();
+        expect(SdkConfig.get("validated_server_config").hsUrl).toBe("https://matrix-client.matrix.org");
+    });
+
+    it(
+        "should not throw when both default_server_name and default_server_config is specified " +
+            "and default_server_name isn't resolvable",
+        async function () {
+            fetchMock.get("https://matrix.org/.well-known/matrix/client", 500);
+            SdkConfig.put({
+                default_server_name: "matrix.org",
+                default_server_config: {
+                    "m.homeserver": {
+                        base_url: "https://matrix-client.matrix.org",
+                    },
+                },
+            });
+            await loadApp();
+            expect(SdkConfig.get("validated_server_config").hsUrl).toBe("https://matrix-client.matrix.org");
+        },
+    );
+});


### PR DESCRIPTION
Closes https://github.com/vector-im/element-web/pull/19695
For https://github.com/vector-im/element-web/issues/11154

The configuration provided with default_server_config can be used as a suitable fallback in case the well-known discovery failed.

Using either of `default_server_config` or `default_server_name` is still supported and works like before.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow default_server_config as a fallback config ([\#25682](https://github.com/vector-im/element-web/pull/25682)). Contributed by @ShadowRZ.<!-- CHANGELOG_PREVIEW_END -->