### PR TITLE
Deprecate customisations in favour of Module API

### DIFF
--- a/docs/customisations.md
+++ b/docs/customisations.md
@@ -1,5 +1,13 @@
 # Customisations
 
+### 🦖 DEPRECATED
+
+Customisations have been deprecated in favour of the [Module API](https://github.com/vector-im/element-web/blob/develop/docs/modules.md).
+If you have use cases from customisations which are not yet available via the Module API please open an issue.
+Customisations will be removed from the codebase in a future release.
+
+---
+
 Element Web and the React SDK support "customisation points" that can be used to
 easily add custom logic specific to a particular deployment of Element Web.
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,15 @@ try {
     // stringify the output so it appears in logs correctly, as large files can sometimes get
     // represented as `<Object>` which is less than helpful.
     console.log("Using customisations.json : " + JSON.stringify(fileOverrides, null, 4));
+
+    process.on("exit", () => {
+        console.log(""); // blank line
+        console.warn("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+        console.warn("!! Customisations have been deprecated and will be removed in a future release      !!");
+        console.warn("!! See https://github.com/vector-im/element-web/blob/develop/docs/customisations.md !!");
+        console.warn("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+        console.log(""); // blank line
+    });
 } catch (e) {
     // ignore - not important
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25733

![image](https://github.com/vector-im/element-web/assets/2403652/d260cb93-2bf1-4909-ac47-2bd61f4b22e0)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Deprecate customisations in favour of Module API ([\#25736](https://github.com/vector-im/element-web/pull/25736)). Fixes #25733.<!-- CHANGELOG_PREVIEW_END -->