### PR TITLE
Deprecate camelCase config options

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,13 @@
 # Configuration
 
+### 🦖 Deprecation notice
+
+Configuration keys were previously a mix of camelCase and snake_case.
+We standardised to snake_case but added compatibility for camelCase to all settings.
+This backwards compatibility will be getting removed in a future release so please ensure you are using snake_case.
+
+---
+
 You can configure the app by copying `config.sample.json` to `config.json` or `config.$domain.json` and customising it.
 Element will attempt to load first `config.$domain.json` and if it fails `config.json`. This mechanism allows different
 configuration options depending on if you're hitting e.g. `app1.example.com` or `app2.example.com`. Configs are not mixed


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-react-sdk/pull/11261

This is to lower the maintenance & support burden when users try and mix both variants in the same configuration and the confusion that may cause.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Deprecate camelCase config options ([\#25800](https://github.com/vector-im/element-web/pull/25800)).<!-- CHANGELOG_PREVIEW_END -->