### PR TITLE
Switch to the new `session` API for screen-sharing

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -32,7 +32,8 @@ type ElectronChannel =
     | "setBadgeCount"
     | "update-downloaded"
     | "userDownloadCompleted"
-    | "userDownloadAction";
+    | "userDownloadAction"
+    | "openDesktopCapturerSourcePicker";
 
 declare global {
     interface Window {

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -169,8 +169,8 @@ export default class ElectronPlatform extends VectorBasePlatform {
             const [source] = await finished;
             if (!source) return;
 
-            this.ipc.call("callDisplayMediaCallback", source)
-        })
+            this.ipc.call("callDisplayMediaCallback", source);
+        });
 
         this.ipc.call("startSSOFlow", this.ssoID);
 
@@ -426,13 +426,13 @@ export default class ElectronPlatform extends VectorBasePlatform {
     public async destroyPickleKey(userId: string, deviceId: string): Promise<void> {
         try {
             await this.ipc.call("destroyPickleKey", userId, deviceId);
-        } catch (e) { }
+        } catch (e) {}
     }
 
     public async clearStorage(): Promise<void> {
         try {
             await super.clearStorage();
             await this.ipc.call("clearStorage");
-        } catch (e) { }
+        } catch (e) {}
     }
 }

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -169,7 +169,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
             const [source] = await finished;
             if (!source) return;
 
-            this.ipc.call("callDisplayMediaCallback", source);
+            await this.ipc.call("callDisplayMediaCallback", source);
         });
 
         this.ipc.call("startSSOFlow", this.ssoID);
@@ -426,13 +426,13 @@ export default class ElectronPlatform extends VectorBasePlatform {
     public async destroyPickleKey(userId: string, deviceId: string): Promise<void> {
         try {
             await this.ipc.call("destroyPickleKey", userId, deviceId);
-        } catch (e) {}
+        } catch (e) { }
     }
 
     public async clearStorage(): Promise<void> {
         try {
             await super.clearStorage();
             await this.ipc.call("clearStorage");
-        } catch (e) {}
+        } catch (e) { }
     }
 }

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -164,12 +164,12 @@ export default class ElectronPlatform extends VectorBasePlatform {
             });
         });
 
-        window.electron.on("openDesktopCapturerSourcePicker", async () => {
+        window.electron.on("openDesktopCapturerSourcePicker", () => {
             const { finished } = Modal.createDialog(DesktopCapturerSourcePicker);
-            const [source] = await finished;
-            if (!source) return;
-
-            await this.ipc.call("callDisplayMediaCallback", source);
+            finished.then(([source]) => {
+                if (!source) return;
+                this.ipc.call("callDisplayMediaCallback", source);
+            });
         });
 
         this.ipc.call("startSSOFlow", this.ssoID);

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -43,6 +43,7 @@ import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { BreadcrumbsStore } from "matrix-react-sdk/src/stores/BreadcrumbsStore";
 import { UPDATE_EVENT } from "matrix-react-sdk/src/stores/AsyncStore";
 import { avatarUrlForRoom, getInitialLetter } from "matrix-react-sdk/src/Avatar";
+import DesktopCapturerSourcePicker from "matrix-react-sdk/src/components/views/elements/DesktopCapturerSourcePicker";
 
 import VectorBasePlatform from "./VectorBasePlatform";
 import { SeshatIndexManager } from "./SeshatIndexManager";
@@ -162,6 +163,14 @@ export default class ElectronPlatform extends VectorBasePlatform {
                 priority: 99,
             });
         });
+
+        window.electron.on("openDesktopCapturerSourcePicker", async () => {
+            const { finished } = Modal.createDialog(DesktopCapturerSourcePicker);
+            const [source] = await finished;
+            if (!source) return;
+
+            this.ipc.call("callDisplayMediaCallback", source)
+        })
 
         this.ipc.call("startSSOFlow", this.ssoID);
 
@@ -417,13 +426,13 @@ export default class ElectronPlatform extends VectorBasePlatform {
     public async destroyPickleKey(userId: string, deviceId: string): Promise<void> {
         try {
             await this.ipc.call("destroyPickleKey", userId, deviceId);
-        } catch (e) {}
+        } catch (e) { }
     }
 
     public async clearStorage(): Promise<void> {
         try {
             await super.clearStorage();
             await this.ipc.call("clearStorage");
-        } catch (e) {}
+        } catch (e) { }
     }
 }

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -169,7 +169,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
             const [source] = await finished;
             if (!source) return;
 
-            await this.ipc.call("callDisplayMediaCallback", source);
+            this.ipc.call("callDisplayMediaCallback", source);
         });
 
         this.ipc.call("startSSOFlow", this.ssoID);

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -426,13 +426,13 @@ export default class ElectronPlatform extends VectorBasePlatform {
     public async destroyPickleKey(userId: string, deviceId: string): Promise<void> {
         try {
             await this.ipc.call("destroyPickleKey", userId, deviceId);
-        } catch (e) { }
+        } catch (e) {}
     }
 
     public async clearStorage(): Promise<void> {
         try {
             await super.clearStorage();
             await this.ipc.call("clearStorage");
-        } catch (e) { }
+        } catch (e) {}
     }
 }

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -169,7 +169,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
             const [source] = await finished;
             if (!source) return;
 
-            this.ipc.call("callDisplayMediaCallback", source);
+            await this.ipc.call("callDisplayMediaCallback", source);
         });
 
         this.ipc.call("startSSOFlow", this.ssoID);

--- a/test/unit-tests/vector/platform/ElectronPlatform-test.ts
+++ b/test/unit-tests/vector/platform/ElectronPlatform-test.ts
@@ -21,6 +21,9 @@ import { Action } from "matrix-react-sdk/src/dispatcher/actions";
 import dispatcher from "matrix-react-sdk/src/dispatcher/dispatcher";
 import * as rageshake from "matrix-react-sdk/src/rageshake/rageshake";
 import { BreadcrumbsStore } from "matrix-react-sdk/src/stores/BreadcrumbsStore";
+import Modal from "matrix-react-sdk/src/Modal";
+import DesktopCapturerSourcePicker from "matrix-react-sdk/src/components/views/elements/DesktopCapturerSourcePicker";
+import { mocked } from "jest-mock";
 
 import ElectronPlatform from "../../../../src/vector/platform/ElectronPlatform";
 
@@ -74,6 +77,23 @@ describe("ElectronPlatform", () => {
         handler();
 
         expect(dispatchFireSpy).toHaveBeenCalledWith(Action.ViewUserSettings);
+    });
+
+    it("creates a modal on openDesktopCapturerSourcePicker", async () => {
+        new ElectronPlatform();
+        Modal.createDialog = jest.fn();
+        mocked(Modal.createDialog).mockReturnValue({
+            // @ts-ignore mock
+            finished: ["source"],
+        });
+        mockElectron.send.mockClear();
+
+        const [event, handler] = getElectronEventHandlerCall("openDesktopCapturerSourcePicker")!;
+        await handler();
+
+        expect(event).toBeTruthy();
+        expect(Modal.createDialog).toHaveBeenCalledWith(DesktopCapturerSourcePicker);
+        expect(mockElectron.send).toHaveBeenCalledWith("callDisplayMediaCallback", "source");
     });
 
     describe("updates", () => {

--- a/test/unit-tests/vector/platform/ElectronPlatform-test.ts
+++ b/test/unit-tests/vector/platform/ElectronPlatform-test.ts
@@ -86,14 +86,19 @@ describe("ElectronPlatform", () => {
             // @ts-ignore mock
             finished: ["source"],
         });
-        mockElectron.send.mockClear();
 
         const [event, handler] = getElectronEventHandlerCall("openDesktopCapturerSourcePicker")!;
         await handler();
 
         expect(event).toBeTruthy();
         expect(Modal.createDialog).toHaveBeenCalledWith(DesktopCapturerSourcePicker);
-        expect(mockElectron.send).toHaveBeenCalledWith("callDisplayMediaCallback", "source");
+        expect(mockElectron.send).toHaveBeenCalledWith(
+            "ipcCall",
+            expect.objectContaining({
+                args: ["source"],
+                name: "callDisplayMediaCallback",
+            }),
+        );
     });
 
     describe("updates", () => {

--- a/test/unit-tests/vector/platform/ElectronPlatform-test.ts
+++ b/test/unit-tests/vector/platform/ElectronPlatform-test.ts
@@ -80,25 +80,23 @@ describe("ElectronPlatform", () => {
     });
 
     it("creates a modal on openDesktopCapturerSourcePicker", async () => {
-        new ElectronPlatform();
+        const plat = new ElectronPlatform();
         Modal.createDialog = jest.fn();
         mocked(Modal.createDialog).mockReturnValue({
             // @ts-ignore mock
             finished: ["source"],
         });
 
+        // @ts-ignore mock
+        jest.spyOn(plat.ipc, "call").mockResolvedValue(undefined);
+
         const [event, handler] = getElectronEventHandlerCall("openDesktopCapturerSourcePicker")!;
         await handler();
 
         expect(event).toBeTruthy();
         expect(Modal.createDialog).toHaveBeenCalledWith(DesktopCapturerSourcePicker);
-        expect(mockElectron.send).toHaveBeenCalledWith(
-            "ipcCall",
-            expect.objectContaining({
-                args: ["source"],
-                name: "callDisplayMediaCallback",
-            }),
-        );
+        // @ts-ignore mock
+        expect(plat.ipc.call).toHaveBeenCalledWith("callDisplayMediaCallback", "source");
     });
 
     describe("updates", () => {


### PR DESCRIPTION
See https://github.com/electron/electron/pull/30702 - this has the benefit of the js-sdk and LiveKit not having to add custom logic for Electron

Requires https://github.com/vector-im/element-desktop/pull/1081
Requires https://github.com/matrix-org/matrix-react-sdk/pull/11266

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->