### PR TITLE
Remove redundant dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,13 +73,11 @@
         "@matrix-org/react-sdk-module-api": "^1.0.0",
         "gfm.css": "^1.1.2",
         "jsrsasign": "^10.5.25",
-        "katex": "^0.16.0",
         "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
         "matrix-react-sdk": "github:matrix-org/matrix-react-sdk#develop",
         "matrix-widget-api": "^1.3.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "sanitize-html": "^2.3.2",
         "ua-parser-js": "^1.0.0"
     },
     "devDependencies": {
@@ -112,7 +110,6 @@
         "@types/node": "^16",
         "@types/react": "17.0.58",
         "@types/react-dom": "17.0.19",
-        "@types/sanitize-html": "^2.3.1",
         "@types/ua-parser-js": "^0.7.36",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,8 +216,7 @@ module.exports = (env, argv) => {
                 // Same goes for js/react-sdk - we don't need two copies.
                 "matrix-js-sdk": path.resolve(__dirname, "node_modules/matrix-js-sdk"),
                 "matrix-react-sdk": path.resolve(__dirname, "node_modules/matrix-react-sdk"),
-                // and sanitize-html & matrix-events-sdk & matrix-widget-api
-                "sanitize-html": path.resolve(__dirname, "node_modules/sanitize-html"),
+                // and matrix-events-sdk & matrix-widget-api
                 "matrix-events-sdk": path.resolve(__dirname, "node_modules/matrix-events-sdk"),
                 "matrix-widget-api": path.resolve(__dirname, "node_modules/matrix-widget-api"),
 


### PR DESCRIPTION
matrix-react-sdk consumes them and has its own dependencies to them

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->