### PR TITLE
Bump @matrix-org/react-sdk-module-api from 1.0.0 to 2.0.0

### DIFF
--- a/module_system/installer.ts
+++ b/module_system/installer.ts
@@ -185,9 +185,20 @@ function getModuleApiVersionFor(moduleName: string): string {
     return findDepVersionInPackageJson(moduleApiDepName, pkgJsonStr);
 }
 
+// A list of Module API versions that are supported in addition to the currently installed one
+// defined in the package.json. This is necessary because semantic versioning is applied to both
+// the Module-side surface of the API and the Client-side surface of the API. So breaking changes
+// in the Client-side surface lead to a major bump even though the Module-side surface stays
+// compatible. We aim to not break the Module-side surface so we maintain a list of compatible
+// older versions.
+const backwardsCompatibleMajorVersions = ["1.0.0"];
+
 function isModuleVersionCompatible(ourApiVersion: string, moduleApiVersion: string): boolean {
     if (!moduleApiVersion) return false;
-    return semver.satisfies(ourApiVersion, moduleApiVersion);
+    return (
+        semver.satisfies(ourApiVersion, moduleApiVersion) ||
+        backwardsCompatibleMajorVersions.some((version) => semver.satisfies(version, moduleApiVersion))
+    );
 }
 
 function writeModulesTs(content: string): void {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "dependencies": {
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
-        "@matrix-org/react-sdk-module-api": "^1.0.0",
+        "@matrix-org/react-sdk-module-api": "^2.0.0",
         "gfm.css": "^1.1.2",
         "jsrsasign": "^10.5.25",
         "katex": "^0.16.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,6 +216,10 @@ module.exports = (env, argv) => {
                 // Same goes for js/react-sdk - we don't need two copies.
                 "matrix-js-sdk": path.resolve(__dirname, "node_modules/matrix-js-sdk"),
                 "matrix-react-sdk": path.resolve(__dirname, "node_modules/matrix-react-sdk"),
+                "@matrix-org/react-sdk-module-api": path.resolve(
+                    __dirname,
+                    "node_modules/@matrix-org/react-sdk-module-api",
+                ),
                 // and matrix-events-sdk & matrix-widget-api
                 "matrix-events-sdk": path.resolve(__dirname, "node_modules/matrix-events-sdk"),
                 "matrix-widget-api": path.resolve(__dirname, "node_modules/matrix-widget-api"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,6 +1636,13 @@
   dependencies:
     "@babel/runtime" "^7.17.9"
 
+"@matrix-org/react-sdk-module-api@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/react-sdk-module-api/-/react-sdk-module-api-2.0.0.tgz#f894af429ad352d5151dc7240cc2f987d9dab780"
+  integrity sha512-o/M+IfB3bu4S3yTO10zMRiEtTQagV9AJ9cNmq8a/ksniCx3QLShtzWeL5FkTa8co0ab/VdxdqTlEux0aStT/dg==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Depends on https://github.com/matrix-org/matrix-react-sdk/pull/11395.

This PR includes two more changes:

### 1. Have Element compatible with multiple versions of the Module API at the same time

Based on the discussion in [#element-dev:matrix.org](https://matrix.to/#/!bEWtlqtDwCLFIAKAcv:matrix.org/$0eFIe7B850Og0VsX3_AyACHcZVrva7Wzi3d25JfZOT0?via=matrix.org&via=element.io&via=envs.net). Gist: The semantic version of the Module API is not a good indicator for the compatibility of a module to the client. Element can accept modules that run on older versions of the module api as long as the Module-Surface-API stays compatible. If any non-backwards compatible change to the Module part of the API happens, this list must be reset.

### 2. Make sure only a single copy of the Module API is used

This was already the case without **1.**, but now it is inevitable. Some parts of the Module API [rely on global variables](https://github.com/matrix-org/matrix-react-sdk/blob/33ec7147d64e540fe2f54faf3de1f9e66bac5b50/src/modules/ModuleComponents.tsx#L24-L38), so every module must use the same instance of the module API package. **1.** requires that all modules can work with all compatible versions of the Module API, so it should be acceptable to let webpack force to resolve it to a single instance.

An example where this breaks. Note that left [shows the fallback textfield](https://github.com/matrix-org/matrix-react-sdk-module-api/blob/6a605f6b390dff4b461ad290f284b79437ba9b55/src/components/TextInputField.tsx#L31-L36) and right [the correct component](https://github.com/matrix-org/matrix-react-sdk/blob/33ec7147d64e540fe2f54faf3de1f9e66bac5b50/src/modules/ModuleComponents.tsx#L31-L39).

| `develop` branch | this PR |
|--|--|
| <img width="300" alt="image" src="https://github.com/vector-im/element-web/assets/720821/6be126d6-ca89-4e28-9245-9a1d4f1aa82d"> | <img width="300" alt="image" src="https://github.com/vector-im/element-web/assets/720821/98be80a7-2365-40ab-a600-a67a995f60ef"> |

>  (checkout `develop`, add `"@vector-im/element-web-ilag-module@0.0.4"` to the `build_config.yaml`, open the url to a public room in an incognito tab, and try to join as guest)

This error will only be testable when we have e2e tests for the Module API. I hope [this discussion](https://github.com/matrix-org/matrix-react-sdk/pull/11396) doesn't block this PR.


## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->