### PR TITLE
Fix path separator for Windows based systems

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -275,7 +275,7 @@ module.exports = (env, argv) => {
                         // either webpack or our babel setup.
                         // When we do get to upgrade our current setup, this should
                         // probably be removed.
-                        if (f.includes("@vector-im/compound-web")) return true;
+                        if (f.includes(path.join("@vector-im", "compound-web"))) return true;
 
                         // but we can't run all of our dependencies through babel (many of them still
                         // use module.exports which breaks if babel injects an 'include' for its


### PR DESCRIPTION
Fixes an issue where the path separator is incorrect for Windows systems

![image](https://github.com/vector-im/element-web/assets/769871/3d8c6c15-30e4-4fbe-9193-70c9cc09432c)

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix path separator for Windows based systems ([\#25997](https://github.com/vector-im/element-web/pull/25997)).<!-- CHANGELOG_PREVIEW_END -->