### PR TITLE
Make SVGR icons use forward ref

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -524,6 +524,12 @@ module.exports = (env, argv) => {
                                         removeDimensions: true,
                                     },
                                 },
+                                /**
+                                 * Forwards the React ref to the root SVG element
+                                 * Useful when using things like `asChild` in
+                                 * radix-ui
+                                 */
+                                ref: true,
                                 esModule: false,
                                 name: "[name].[hash:7].[ext]",
                                 outputPath: getAssetOutputPath,


### PR DESCRIPTION
Needed for tooltips to work on icons, https://github.com/vector-im/compound/issues/152

Radix UI uses the [`asChild` pattern](https://www.radix-ui.com/primitives/docs/guides/composition) that relies heavily on forwarded refs in React. 

See https://react-svgr.com/docs/options/#ref

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Make SVGR icons use forward ref ([\#26082](https://github.com/vector-im/element-web/pull/26082)).<!-- CHANGELOG_PREVIEW_END -->