### PR TITLE
Turn off new room header by default

### DIFF
--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -48,8 +48,7 @@
     },
     "privacy_policy_url": "https://element.io/cookie-policy",
     "features": {
-        "feature_video_rooms": true,
-        "feature_new_room_decoration_ui": true
+        "feature_video_rooms": true
     },
     "element_call": {
         "url": "https://element-call-livekit.netlify.app"


### PR DESCRIPTION
Early feedback indicates that the defaulting happened prematurely.

This undoes https://github.com/vector-im/element-web/pull/26089.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->