### PR TITLE
Bump matrix-web-i18n to 3.1.3 for KEY_SEPARATOR

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
         "json-loader": "^0.5.7",
         "loader-utils": "^3.0.0",
         "matrix-mock-request": "^2.5.0",
-        "matrix-web-i18n": "^3.1.1",
+        "matrix-web-i18n": "^3.1.3",
         "mini-css-extract-plugin": "^1",
         "minimist": "^1.2.6",
         "mkdirp": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9020,10 +9020,10 @@ matrix-react-sdk@3.82.0-rc.1:
     uuid "^9.0.0"
     what-input "^5.2.10"
 
-matrix-web-i18n@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/matrix-web-i18n/-/matrix-web-i18n-3.1.1.tgz#da851748515b20ca15fa986817bbce2e242b3dd6"
-  integrity sha512-BOeOTedtONIqVQUlyHFXpxXkrETWdCoJdToyA+edMU+yGjKOW7bekAd9uAEfkV9jErP5eXw3cHYsKZPpa8ifWg==
+matrix-web-i18n@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/matrix-web-i18n/-/matrix-web-i18n-3.1.3.tgz#b462015b138ebdd288ed945507abea42c896f52d"
+  integrity sha512-9JUUTifqS/Xe6YQr5uDbX04xvr5Pxg8aU7tRKx49/ZLqm4dZoJKo4SKpyLEwCQeNjAvjcKuXibWO+2hkZ2/Ojw==
   dependencies:
     "@babel/parser" "^7.18.5"
     "@babel/traverse" "^7.18.5"


### PR DESCRIPTION
Translations were missing when we deployed today's release to staging, and we think this was why. The running cod didn't have a key separator set in counterpart.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Bump matrix-web-i18n to 3.1.3 for KEY_SEPARATOR ([\#26287](https://github.com/vector-im/element-web/pull/26287)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->