### PR TITLE
vector-im/element-x-ios/issues/1824 - Convert the apple-app-site-association file to a newer format…

### DIFF
--- a/res/apple-app-site-association
+++ b/res/apple-app-site-association
@@ -1,26 +1,35 @@
 {
-    "applinks": {
-        "apps": [],
-        "details": [
-            {
-                "appIDs":[
-                    "7J4U792NQT.im.vector.app",
-                    "7J4U792NQT.io.element.elementx",
-                    "7J4U792NQT.io.element.elementx.nightly",
-                    "7J4U792NQT.io.element.elementx.pr"
-                ],
-                "paths": [
-                    "*"
-                ]
-            }
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "7J4U792NQT.im.vector.app",
+          "7J4U792NQT.io.element.elementx",
+          "7J4U792NQT.io.element.elementx.nightly",
+          "7J4U792NQT.io.element.elementx.pr"
+        ],
+        "components": [
+          {
+            "?": {
+              "no_universal_links": "?*"
+            },
+            "exclude": true,
+            "comment": "Opt out of universal links"
+          },
+          {
+            "/": "/*",
+            "comment": "Matches any URL"
+          }
         ]
-    },
-    "webcredentials": {
-        "apps": [
-            "7J4U792NQT.im.vector.app",
-            "7J4U792NQT.io.element.elementx",
-            "7J4U792NQT.io.element.elementx.nightly",
-            "7J4U792NQT.io.element.elementx.pr"
-        ]
-    }
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": [
+      "7J4U792NQT.im.vector.app",
+      "7J4U792NQT.io.element.elementx",
+      "7J4U792NQT.io.element.elementx.nightly",
+      "7J4U792NQT.io.element.elementx.pr"
+    ]
+  }
 }


### PR DESCRIPTION
… and introduce an option to opt out of universal links; reformat json.

Following the lessons learned from https://github.com/vector-im/element-x-ios/issues/1824 we would like to apply the [solution from element call](https://github.com/vector-im/element-call/pull/1693) here too. 

Ideally the `apple-app-site-association` file should be moved under `.well-known` but I couldn't figure out how to do that. The old paths are deprecated but they still work just fine for now.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * vector-im/element-x-ios/issues/1824 - Convert the apple-app-site-association file to a newer format… ([\#26307](https://github.com/vector-im/element-web/pull/26307)). Contributed by @stefanceriu.<!-- CHANGELOG_PREVIEW_END -->