### PR TITLE
Update Linux Kernel link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ and we'll try to fix it :)
 In order to have a concrete record that your contribution is intentional
 and you agree to license it under the same terms as the project's license, we've
 adopted the same lightweight approach that the Linux Kernel
-(https://www.kernel.org/doc/Documentation/SubmittingPatches), Docker
+(https://www.kernel.org/doc/html/latest/process/submitting-patches.html), Docker
 (https://github.com/docker/docker/blob/master/CONTRIBUTING.md), and many other
 projects use: the DCO (Developer Certificate of Origin:
 http://developercertificate.org/). This is a simple declaration that you wrote


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->


This PR addresses a minor issue in the CONTRIBUTING.md file under [Sign off](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md#sign-off) where the link to the Linux Kernel documentation have been moved to another link as described in (https://www.kernel.org/doc/Documentation/SubmittingPatches).

Signed-off-by: dharshan <dharshan2457@gmail.com>

Before:
- [Linux Kernel doc link](https://www.kernel.org/doc/Documentation/SubmittingPatches)

After:
- [Linux Kernel doc link](https://www.kernel.org/doc/html/latest/process/submitting-patches.html)

This change is trivial and should have no functional impact on the project. It simply ensures that contributors can easily access the correct Linux Kernel documentation for submitting-patches.

Please review and merge this PR. Thank you!



## Checklist

-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->