### PR TITLE
Update the Element Call unstable URL

### DIFF
--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -51,7 +51,7 @@
         "feature_video_rooms": true
     },
     "element_call": {
-        "url": "https://element-call-livekit.netlify.app"
+        "url": "https://call.element.dev"
     },
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
 }


### PR DESCRIPTION
We've switched from Netlify to an in-house Kubernetes deployment with a new URL.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->