### PR TITLE
Correctly fill window.matrixChat even when a Wrapper module is active

### DIFF
--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -65,7 +65,7 @@ function onTokenLoginCompleted(): void {
     window.history.replaceState(null, "", url.href);
 }
 
-export async function loadApp(fragParams: {}): Promise<ReactElement> {
+export async function loadApp(fragParams: {}, matrixChatRef: React.Ref<MatrixChat>): Promise<ReactElement> {
     initRouting();
     const platform = PlatformPeg.get();
 
@@ -117,6 +117,7 @@ export async function loadApp(fragParams: {}): Promise<ReactElement> {
     return (
         <wrapperOpts.Wrapper>
             <MatrixChat
+                ref={matrixChatRef}
                 onNewScreen={onNewScreen}
                 config={config}
                 realQueryParams={params}

--- a/src/vector/init.tsx
+++ b/src/vector/init.tsx
@@ -30,6 +30,7 @@ import SdkConfig from "matrix-react-sdk/src/SdkConfig";
 import { setTheme } from "matrix-react-sdk/src/theme";
 import { logger } from "matrix-js-sdk/src/logger";
 import { ModuleRunner } from "matrix-react-sdk/src/modules/ModuleRunner";
+import MatrixChat from "matrix-react-sdk/src/components/structures/MatrixChat";
 
 import ElectronPlatform from "./platform/ElectronPlatform";
 import PWAPlatform from "./platform/PWAPlatform";
@@ -147,7 +148,10 @@ export async function loadApp(fragParams: {}): Promise<void> {
         /* webpackPreload: true */
         "./app"
     );
-    window.matrixChat = ReactDOM.render(await module.loadApp(fragParams), document.getElementById("matrixchat"));
+    function setWindowMatrixChat(matrixChat: MatrixChat): void {
+        window.matrixChat = matrixChat;
+    }
+    ReactDOM.render(await module.loadApp(fragParams, setWindowMatrixChat), document.getElementById("matrixchat"));
 }
 
 export async function showError(title: string, messages?: string[]): Promise<void> {

--- a/test/app-tests/server-config-test.ts
+++ b/test/app-tests/server-config-test.ts
@@ -47,7 +47,7 @@ describe("Loading server config", function () {
                 },
             },
         });
-        await loadApp({});
+        await loadApp({}, null);
         expect((SdkConfig.get("validated_server_config") || {}).hsUrl).toBe("https://matrix-client.matrix.org");
     });
 
@@ -55,7 +55,7 @@ describe("Loading server config", function () {
         SdkConfig.put({
             default_server_name: "matrix.org",
         });
-        await loadApp({});
+        await loadApp({}, null);
         expect((SdkConfig.get("validated_server_config") || {}).hsUrl).toBe("https://matrix-client.matrix.org");
     });
 
@@ -72,7 +72,7 @@ describe("Loading server config", function () {
                     },
                 },
             });
-            await loadApp({});
+            await loadApp({}, null);
             expect((SdkConfig.get("validated_server_config") || {}).hsUrl).toBe("https://matrix-client.matrix.org");
         },
     );

--- a/test/app-tests/wrapper-test.tsx
+++ b/test/app-tests/wrapper-test.tsx
@@ -22,6 +22,7 @@ import fetchMock from "fetch-mock-jest";
 import { render, RenderResult, screen } from "@testing-library/react";
 import { ModuleRunner } from "matrix-react-sdk/src/modules/ModuleRunner";
 import { WrapperLifecycle, WrapperOpts } from "@matrix-org/react-sdk-module-api/lib/lifecycles/WrapperLifecycle";
+import MatrixChat from "matrix-react-sdk/src/components/structures/MatrixChat";
 
 import WebPlatform from "../../src/vector/platform/WebPlatform";
 import { loadApp } from "../../src/vector/app";
@@ -68,7 +69,8 @@ describe("Wrapper", () => {
             }
         });
 
-        const matrixChatResult: RenderResult = render(await loadApp({}));
+        const ref = React.createRef<MatrixChat>();
+        const matrixChatResult: RenderResult = render(await loadApp({}, ref));
 
         // at this point, we're trying to do a guest registration;
         // we expect a spinner
@@ -83,5 +85,8 @@ describe("Wrapper", () => {
 
         expect(header.nextSibling).toBe(matrixChat);
         expect(matrixChat.nextSibling).toBe(footer);
+
+        // Should still hold a reference to the MatrixChat component
+        expect(ref.current).toBeInstanceOf(MatrixChat);
     });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

When a module with the [WrapperLifecycle](https://github.com/matrix-org/matrix-react-sdk-module-api/blob/dae6a5ad26af9a2336520753035e28f2e2035549/src/lifecycles/WrapperLifecycle.ts) is active, some features don't work anymore. This affects for example the [`navigateTo`](https://github.com/matrix-org/matrix-widget-api/blob/9ab62e72c8b98087edcf1748d8c9c9f75631d030/src/WidgetApi.ts#L590-L598) feature of the Widget API. This is caused because the `hashchange` event listener is depending [on the `window.matrixChat` variable](https://github.com/nordeck/element-web/blob/53bf443dbbaefb9bf3031564a60c2ae2d88dc526/src/vector/routing.ts#L37-L43), but that is not pointing to the `MatrixChat` component when a Wrapper component is added.

We now worked-around the issue by making the Wrapper a class and forwarding the relevant calls to the chat component in our module, but that is more a hack than a real solution.

From what I read, it is not recommended to use the return value of `ReactDOM.render(...)`. It will only work for class components and will also not be available in the new React 18 APIs. Instead, I propose to just use Ref's which are the recommended way to receive a reference to a component instance.

I test this in the `wrapper-test.tsx` but am not sure if we need more tests. For now the `window.matrixChat` variable is not tested, though we probably could create a Cypress test for that if we want to(?)

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Correctly fill window.matrixChat even when a Wrapper module is active ([\#26395](https://github.com/vector-im/element-web/pull/26395)). Contributed by @dhenneke.<!-- CHANGELOG_PREVIEW_END -->

Type: enhancement