### PR TITLE
Use only chokidar for watching and add more logging

### DIFF
--- a/scripts/copy-res.ts
+++ b/scripts/copy-res.ts
@@ -22,9 +22,6 @@ const INCLUDE_LANGS = [...new Set([...fs.readdirSync(I18N_BASE_PATH), ...fs.read
 const COPY_LIST: [
     sourceGlob: string,
     outputPath: string,
-    opts?: {
-        directwatch?: 1;
-    },
 ][] = [
     ["res/apple-app-site-association", "webapp"],
     ["res/manifest.json", "webapp"],
@@ -35,8 +32,8 @@ const COPY_LIST: [
     ["res/vector-icons/**", "webapp/vector-icons"],
     ["res/decoder-ring/**", "webapp/decoder-ring"],
     ["node_modules/matrix-react-sdk/res/media/**", "webapp/media"],
-    ["node_modules/@matrix-org/olm/olm_legacy.js", "webapp", { directwatch: 1 }],
-    ["./config.json", "webapp", { directwatch: 1 }],
+    ["node_modules/@matrix-org/olm/olm_legacy.js", "webapp"],
+    ["./config.json", "webapp"],
     ["contribute.json", "webapp"],
 ];
 const argv = parseArgs(process.argv.slice(2), {});
@@ -60,6 +57,22 @@ if (!fs.existsSync("webapp/i18n/")) {
     fs.mkdirSync("webapp/i18n/");
 }
 
+function createCpx(source: string, dest: string): Cpx {
+    const cpx = new Cpx(source, dest);
+    if (verbose) {
+        cpx.on("copy", (event) => {
+            console.log(`Copied: ${event.srcPath} --> ${event.dstPath}`);
+        });
+    }
+    return cpx;
+};
+
+const logWatch = (path: string) => {
+    if (verbose) {
+        console.log(`Watching: ${path}`);
+    }
+};
+
 function next(i: number, err?: Error): void {
     errCheck(err);
 
@@ -70,39 +83,26 @@ function next(i: number, err?: Error): void {
     const ent = COPY_LIST[i];
     const source = ent[0];
     const dest = ent[1];
-    const opts = ent[2] || {};
-    const cpx = new Cpx(source, dest);
-
-    if (verbose) {
-        cpx.on("copy", (event) => {
-            console.log(`Copied: ${event.srcPath} --> ${event.dstPath}`);
-        });
-        cpx.on("remove", (event) => {
-            console.log(`Removed: ${event.path}`);
-        });
-    }
 
     const cb = (err?: Error): void => {
         next(i + 1, err);
     };
 
     if (watch) {
-        if (opts.directwatch) {
-            // cpx -w creates a watcher for the parent of any files specified,
-            // which in the case of config.json is '.', which inevitably takes
-            // ages to crawl. So we create our own watcher on the files
-            // instead.
-            const copy = (): void => {
-                cpx.copy(errCheck);
-            };
-            chokidar.watch(source).on("add", copy).on("change", copy).on("ready", cb).on("error", errCheck);
-        } else {
-            cpx.on("watch-ready", cb);
-            cpx.on("watch-error", cb);
-            cpx.watch();
-        }
+        // cpx -w creates a watcher for the parent of any files specified,
+        // which in the case of e.g. config.json is '.', which inevitably takes
+        // ages to crawl. To prevent this, we only use cpx for copying and resort
+        // to chokidar for watching.
+        const copy = (path: string): void => {
+            createCpx(path, dest).copy(errCheck);
+        };
+        chokidar.watch(source)
+            .on("ready", () => { logWatch(source); cb(); })
+            .on("add", copy)
+            .on("change", copy)
+            .on("error", errCheck);
     } else {
-        cpx.copy(cb);
+        createCpx(source, dest).copy(cb);
     }
 }
 
@@ -182,7 +182,11 @@ function watchLanguage(lang: string, dest: string, langFileMap: Record<string, s
     };
 
     [reactSdkFile, riotWebFile].forEach(function (f) {
-        chokidar.watch(f).on("add", makeLang).on("change", makeLang).on("error", errCheck);
+        chokidar.watch(f)
+            .on("ready", () => { logWatch(f); })
+            .on("add", makeLang)
+            .on("change", makeLang)
+            .on("error", errCheck);
     });
 }
 


### PR DESCRIPTION
We're currently using both cpx and chokidar for watching files in `copy-res.ts`. This is suboptimal because:

1. cpx is slow when watching files in large directories
2. We have to maintain two different ways of watching in the script which increases complexity

This pull request switches all watching in the script to use chokidar. This reduces the initial runtime of `yarn run ts-node scripts/copy-res.ts -v -w` from 4.5s to 2.4s on my machine[^1]. Additionally logging for the watcher setup is added in verbose mode.

[^1]: It's worth pointing out that most of the speed-up could also have been had by setting `directwatch: 1` on `contribute.json`.