### PR TITLE
Enable new room header by default on develop

### DIFF
--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -49,7 +49,8 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "features": {
         "feature_video_rooms": true,
-        "feature_rust_crypto": true
+        "feature_rust_crypto": true,
+        "feature_new_room_decoration_ui": true
     },
     "element_call": {
         "url": "https://call.element.dev"


### PR DESCRIPTION
Relates to: vector-im/element-web#25883

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->