### PR TITLE
Fix assets path issue for "compound-design-tokens" package

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -807,7 +807,7 @@ function getAssetOutputPath(url, resourcePath) {
     const isKaTeX = resourcePath.includes("KaTeX");
     // `res` is the parent dir for our own assets in various layers
     // `dist` is the parent dir for KaTeX assets
-    const prefix = /^.*[/\\](dist|res)[/\\]/;
+    const prefix = /^.*[/\\](dist|res|compound-design-tokens)[/\\]/;
 
     /**
      * Only needed for https://github.com/vector-im/element-web/pull/15939
@@ -818,20 +818,6 @@ function getAssetOutputPath(url, resourcePath) {
         throw new Error(`Unexpected asset path: ${resourcePath}`);
     }
     let outputDir = path.dirname(resourcePath).replace(prefix, "");
-
-    /**
-     * Imports from Compound are "absolute", we need to strip out the prefix
-     * coming before the npm package name.
-     *
-     * This logic is scoped to compound packages for now as they are the only
-     * package that imports external assets. This might need to be made more
-     * generic in the future
-     */
-    const compoundImportsPrefix = /@vector-im(?:\\|\/)compound-(.*?)(?:\\|\/)/;
-    const compoundMatch = outputDir.match(compoundImportsPrefix);
-    if (compoundMatch) {
-        outputDir = outputDir.substring(compoundMatch.index + compoundMatch[0].length);
-    }
 
     if (isKaTeX) {
         // Add a clearly named directory segment, rather than leaving the KaTeX


### PR DESCRIPTION
The fix, given here https://github.com/vector-im/element-web/pull/26069, does not work if one clone the `compound-design-tokens` package separately and link it within the `matrix-react-sdk`, because the regex `/@vector-im(?:\\|\/)compound-(.*?)(?:\\|\/)/` does not match the different paths that does not contain the string `@vector-im`, see below (Cloned & linked package):

Resource paths (on Windows) are e.g. ...

- Not linked package -
`resourcePath: C:\src\matrix-react-sdk\node_modules\@vector-im\compound-design-tokens\icons\chat-solid.svg`

- Cloned & linked package -
`resourcePath: C:\src\compound-design-tokens\icons\chat-solid.svg`


Problem: 
The main problem is not whether absolute vs relative paths but that the `compound-design-tokens` package does not have a `dist` or `res` subfolder to serve the assets so that the existing regex `/^.*[/\\](dist|res)[/\\]/` does not match.

Solution:
The solution is to add the missing root folder name for the assets to the above regex, with ...
`/^.*[/\](dist|res|compound-design-tokens)[/\]/`


I have tested this for both scenarios (linked/not linked) on Windows and it works with the regex statement:

`const prefix = /^.*[/\\](dist|res|compound-design-tokens)[/\\]/;`

The full part regarding `compoundImportsPrefix` is in this case obsolete and can be removed in the `webpack.config.js`.


Signed-off-by: menturion <menturion@gmail.com>